### PR TITLE
Fix scroll position not resetting when navigating between pages

### DIFF
--- a/apps/app/src/paths/SiteHeader.tsx
+++ b/apps/app/src/paths/SiteHeader.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Grid, GridItem, SkipNavLink, SkipNavContent } from "@chakra-ui/react";
-import { Outlet, useLoaderData } from "react-router";
+import { Outlet, useLoaderData, useLocation } from "react-router";
 import axios from "axios";
 import {
   ContentDescription,
@@ -20,6 +20,7 @@ export type SiteContext = {
   setAddTo: (_: ContentDescription | null) => void;
   allLicenses: License[];
   allDoenetmlVersions: DoenetmlVersion[];
+  mainRef: React.RefObject<HTMLDivElement | null>;
 };
 
 export async function loader() {
@@ -44,6 +45,20 @@ export async function loader() {
  * and a hamburger menu with drill-down navigation on mobile.
  * Includes skip navigation link for accessibility.
  */
+function ScrollToTop({
+  scrollRef,
+}: {
+  scrollRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: 0 });
+  }, [pathname, scrollRef]);
+
+  return null;
+}
+
 export function SiteHeader() {
   const { user, allLicenses, allDoenetmlVersions } = useLoaderData() as {
     user?: UserInfoWithEmail;
@@ -55,6 +70,8 @@ export function SiteHeader() {
 
   const [addTo, setAddTo] = useState<ContentDescription | null>(null);
 
+  const mainRef = useRef<HTMLDivElement>(null);
+
   const siteContext: SiteContext = {
     user,
     exploreTab,
@@ -63,6 +80,7 @@ export function SiteHeader() {
     setAddTo,
     allLicenses,
     allDoenetmlVersions,
+    mainRef,
   };
 
   return (
@@ -84,8 +102,16 @@ export function SiteHeader() {
         >
           <Navbar user={user} />
         </GridItem>
-        <GridItem as="main" area="main" margin="0" overflowY="auto">
+        <GridItem
+          ref={mainRef}
+          as="main"
+          area="main"
+          margin="0"
+          overflowY="auto"
+          data-test="Main Content"
+        >
           <SkipNavContent />
+          <ScrollToTop scrollRef={mainRef} />
           <Outlet context={siteContext} />
         </GridItem>
       </Grid>

--- a/packages/e2e-tests/e2e/Activities/scrollReset.cy.ts
+++ b/packages/e2e-tests/e2e/Activities/scrollReset.cy.ts
@@ -1,0 +1,41 @@
+describe("Scroll Reset on Navigation", { tags: ["@group2"] }, function () {
+  it("resets scroll position when navigating to a different page", () => {
+    cy.loginAsTestUser();
+
+    // Create content so the activities page has items to display
+    cy.createContent({ name: "Activity 1", doenetML: "Hello!" });
+    cy.createContent({ name: "Activity 2", doenetML: "World!" });
+
+    cy.getUserInfo().then((user) => {
+      // Use a narrow viewport height so the page is scrollable with just a few items
+      cy.viewport(1000, 300);
+
+      cy.visit(`/activities/${user.userId}`);
+
+      // Wait for content to load
+      cy.get('[data-test="Activities"]').should("exist");
+
+      // Verify the main container is scrollable
+      cy.get('[data-test="Main Content"]').should(($el) => {
+        expect($el[0].scrollHeight).to.be.greaterThan($el[0].clientHeight);
+      });
+
+      // Scroll down in the main content area
+      cy.get('[data-test="Main Content"]').scrollTo("bottom");
+
+      // Verify we scrolled down
+      cy.get('[data-test="Main Content"]').should(($el) => {
+        expect($el[0].scrollTop).to.be.greaterThan(0);
+      });
+
+      // Navigate to Explore
+      cy.get('[data-test="Explore"]').click();
+      cy.url().should("include", "/explore");
+
+      // Scroll position should be reset to top after navigation
+      cy.get('[data-test="Main Content"]').should(($el) => {
+        expect($el[0].scrollTop).to.equal(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #2828 (scroll position persists when navigating to another page) and also addresses #2656 (activity viewer loads off-screen after navigating from a scrolled Explore page).

### Root Cause

The main content area in `SiteHeader.tsx` uses `overflowY="auto"` on a `GridItem` element, making that element (not `window`) the scroll container. React Router's built-in scroll restoration only operates on `window`, so scroll position was never reset between page navigations.

### Fix

- Added a `ScrollToTop` component inside the main content `GridItem` that resets `scrollTop` to `0` whenever the route `pathname` changes via `useLocation` + `useEffect`.
- Added a `data-test="Main Content"` attribute to the scrollable container for testability.
- Exposed `mainRef` in `SiteContext` so child components can programmatically interact with the scroll container if needed.

## Test plan

- [x] New e2e test in `packages/e2e-tests/e2e/Activities/scrollReset.cy.ts` verifies that navigating to a different page resets the scroll position to 0
- [ ] Manually: scroll down on any page, navigate to another page via the navbar — verify new page starts at the top
- [ ] Manually: scroll down on Explore, click an activity — verify the activity viewer loads at the top of the screen

https://claude.ai/code/session_01GkbCKnBr4VvMojBVuhULKd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkbCKnBr4VvMojBVuhULKd)_