### PR TITLE
fix: improve checkbox contrast in folder view

### DIFF
--- a/apps/app/src/theme.ts
+++ b/apps/app/src/theme.ts
@@ -40,6 +40,16 @@ const theme = extendTheme({
   components: {
     Button,
     IconButton: Button,
+    Checkbox: {
+      baseStyle: {
+        control: {
+          borderColor: "gray.500",
+          _hover: {
+            borderColor: "gray.600",
+          },
+        },
+      },
+    },
     FormError: {
       baseStyle: {
         text: {


### PR DESCRIPTION
## Summary

- Fixes #2891: checkboxes in the My Activities folder view were very hard to see
- Overrides Chakra UI's default Checkbox border color from `gray.200` (very light, `#E2E8F0`) to `gray.500` (`#718096`), which provides adequate contrast on white backgrounds
- The `_hover` state also gets a slightly darker `gray.600` border for visual feedback
- This applies to all Chakra UI `<Checkbox>` instances across the app (folder view, filter panel, editor, etc.)

## Test plan

- [ ] Visit My Activities folder — checkboxes on each row should now have a clearly visible gray border
- [ ] Verify hover state shows slightly darker border
- [ ] Verify checked state is unchanged (blue fill, white checkmark)
- [ ] Verify disabled checkboxes still render correctly
- [ ] Run existing Cypress component tests (`npm run test:all --workspace @doenet-tools/app`)

https://claude.ai/code/session_01KxyYxeTTrz3tbA9abPP81T

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxyYxeTTrz3tbA9abPP81T)_