### PR TITLE
fix: clear card selection on delete to prevent double-deletion error

### DIFF
--- a/apps/app/src/paths/Activities.tsx
+++ b/apps/app/src/paths/Activities.tsx
@@ -487,6 +487,7 @@ export function Activities() {
       },
       onDelete: () => {
         setSettingsContentId(cardSelections.ids.values().next().value ?? null);
+        cardSelections.clear();
         deleteContentOnOpen();
       },
     });

--- a/apps/app/src/views/CompoundActivityEditor.tsx
+++ b/apps/app/src/views/CompoundActivityEditor.tsx
@@ -443,6 +443,7 @@ export function CompoundActivityEditor({
           (c) => c.contentId === cardSelections.ids.values().next().value,
         );
         if (selectedContent) {
+          cardSelections.clear();
           setContentToDelete(selectedContent);
           deleteContentOnOpen();
         }

--- a/packages/e2e-tests/e2e/Content Lists/deleteFromCompoundActivity.cy.ts
+++ b/packages/e2e-tests/e2e/Content Lists/deleteFromCompoundActivity.cy.ts
@@ -1,0 +1,170 @@
+describe("Delete from compound activity tests", { tags: ["@group3"] }, () => {
+  it("Delete document from problem set", () => {
+    cy.loginAsTestUser();
+
+    cy.createContent({ name: "Problem Set 1", contentType: "sequence" }).then(
+      (sequenceId) => {
+        cy.createContent({
+          name: "Document P1",
+          contentType: "singleDoc",
+          parentId: sequenceId,
+        });
+        cy.createContent({
+          name: "Document P2",
+          contentType: "singleDoc",
+          parentId: sequenceId,
+        });
+        cy.createContent({
+          name: "Document P3",
+          contentType: "singleDoc",
+          parentId: sequenceId,
+        });
+      },
+    );
+
+    cy.visit("/");
+    cy.get('[data-test="My Activities"]').click();
+
+    cy.get(`[data-test="Content Card"]`).should("have.length", 1);
+    cy.get(`[data-test="Content Card"]`)
+      .eq(0)
+      .should("contain.text", "Problem Set 1")
+      .click();
+
+    cy.get('[data-test="Editable Title"]').should("have.text", "Problem Set 1");
+    cy.get(`[data-test="Content Card"]`).should("have.length", 3);
+
+    cy.get('[data-test="Card Select"]').eq(0).click();
+    cy.get('[aria-label="Move to trash"]').click();
+    cy.get('[data-test="Confirm Delete Message"]').should(
+      "contain.text",
+      "Document P1",
+    );
+    cy.get('[data-test="Delete Button"]').click();
+
+    cy.get(`[data-test="Content Card"]`).should("have.length", 2);
+    cy.get(`[data-test="Content Card"]`)
+      .eq(0)
+      .should("contain.text", "Document P2");
+  });
+
+  it("Delete multiple documents sequentially from problem set", () => {
+    cy.loginAsTestUser();
+
+    cy.createContent({ name: "Problem Set 1", contentType: "sequence" }).then(
+      (sequenceId) => {
+        cy.createContent({
+          name: "Document P1",
+          contentType: "singleDoc",
+          parentId: sequenceId,
+        });
+        cy.createContent({
+          name: "Document P2",
+          contentType: "singleDoc",
+          parentId: sequenceId,
+        });
+        cy.createContent({
+          name: "Document P3",
+          contentType: "singleDoc",
+          parentId: sequenceId,
+        });
+      },
+    );
+
+    cy.visit("/");
+    cy.get('[data-test="My Activities"]').click();
+
+    cy.get(`[data-test="Content Card"]`)
+      .eq(0)
+      .should("contain.text", "Problem Set 1")
+      .click();
+
+    cy.get('[data-test="Editable Title"]').should("have.text", "Problem Set 1");
+    cy.get(`[data-test="Content Card"]`).should("have.length", 3);
+
+    // Delete Document P1
+    cy.log("Delete Document P1");
+    cy.get('[data-test="Card Select"]').eq(0).click();
+    cy.get('[aria-label="Move to trash"]').click();
+    cy.get('[data-test="Confirm Delete Message"]').should(
+      "contain.text",
+      "Document P1",
+    );
+    cy.get('[data-test="Delete Button"]').click();
+
+    cy.get(`[data-test="Content Card"]`).should("have.length", 2);
+    cy.get(`[data-test="Content Card"]`)
+      .eq(0)
+      .should("contain.text", "Document P2");
+    cy.get(`[data-test="Content Card"]`)
+      .eq(1)
+      .should("contain.text", "Document P3");
+
+    // Delete Document P2 (second deletion from same problem set)
+    cy.log("Delete Document P2");
+    cy.get('[data-test="Card Select"]').eq(0).click();
+    cy.get('[aria-label="Move to trash"]').click();
+    cy.get('[data-test="Confirm Delete Message"]').should(
+      "contain.text",
+      "Document P2",
+    );
+    cy.get('[data-test="Delete Button"]').click();
+
+    cy.get(`[data-test="Content Card"]`).should("have.length", 1);
+    cy.get(`[data-test="Content Card"]`)
+      .eq(0)
+      .should("contain.text", "Document P3");
+  });
+
+  it("Delete all documents from problem set", () => {
+    cy.loginAsTestUser();
+
+    cy.createContent({
+      name: "Empty Problem Set",
+      contentType: "sequence",
+    }).then((sequenceId) => {
+      cy.createContent({
+        name: "Document A",
+        contentType: "singleDoc",
+        parentId: sequenceId,
+      });
+      cy.createContent({
+        name: "Document B",
+        contentType: "singleDoc",
+        parentId: sequenceId,
+      });
+    });
+
+    cy.visit("/");
+    cy.get('[data-test="My Activities"]').click();
+
+    cy.get(`[data-test="Content Card"]`)
+      .eq(0)
+      .should("contain.text", "Empty Problem Set")
+      .click();
+
+    cy.get('[data-test="Editable Title"]').should(
+      "have.text",
+      "Empty Problem Set",
+    );
+    cy.get(`[data-test="Content Card"]`).should("have.length", 2);
+
+    // Delete Document A
+    cy.get('[data-test="Card Select"]').eq(0).click();
+    cy.get('[aria-label="Move to trash"]').click();
+    cy.get('[data-test="Delete Button"]').click();
+
+    cy.get(`[data-test="Content Card"]`).should("have.length", 1);
+
+    // Delete Document B
+    cy.get('[data-test="Card Select"]').eq(0).click();
+    cy.get('[aria-label="Move to trash"]').click();
+    cy.get('[data-test="Confirm Delete Message"]').should(
+      "contain.text",
+      "Document B",
+    );
+    cy.get('[data-test="Delete Button"]').click();
+
+    cy.get(`[data-test="Content Card"]`).should("have.length", 0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2673 — "Deleting multiple documents from within a problem set causes error"

### Root Cause

After the user confirms a deletion, the card selection was not immediately cleared. During the loader revalidation window (between the API committing the deletion and the updated list rendering), the deleted item was still visible and still selected — with the "Move to trash" button still enabled. If the user clicked "Move to trash" again in this window, the app would try to delete an already-soft-deleted item. The API's `findUniqueOrThrow` (filtered by `isDeletedOn: null`) would throw a P2025 "not found" error, which `genericAction` re-threw, causing the error boundary to render.

### Fix

In both `CompoundActivityEditor` and `Activities`, call `cardSelections.clear()` when the delete confirmation modal opens. This immediately disables the "Move to trash" button (which requires `count === 1`), preventing re-triggering of deletion before the list revalidates.

- `apps/app/src/views/CompoundActivityEditor.tsx` — primary fix for the problem set editor (the reported scenario)
- `apps/app/src/paths/Activities.tsx` — same fix applied to the folder/activities view, which had the identical pattern

### Tests Added

New e2e test file `deleteFromCompoundActivity.cy.ts` covering:
1. Deleting a single document from a problem set
2. Deleting multiple documents sequentially from the same problem set (the main bug scenario)
3. Deleting all documents from a problem set

https://claude.ai/code/session_01Dr269QvNtnGAywEw3Qx36z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr269QvNtnGAywEw3Qx36z)_