### PR TITLE
feat(explore): show helpful message when curated/community tab has no matches but the other does

### DIFF
--- a/apps/app/src/paths/Explore.tsx
+++ b/apps/app/src/paths/Explore.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useMemo, useState } from "react";
+import React, { ReactElement, useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import {
   Box,
@@ -292,15 +292,66 @@ export function Explore() {
       />
     ) : null;
 
+  const curatedEmptyMessage = useMemo(() => {
+    const numCommunity = totalCount.numCommunity ?? 0;
+    if (numCommunity > 0) {
+      return (
+        <VStack spacing={4} data-test="Curated Empty With Community Results">
+          <Text fontSize="36pt">No Curated Matches Found!</Text>
+          <Text fontSize="16pt">
+            There {numCommunity === 1 ? "is" : "are"}{" "}
+            {intWithCommas(numCommunity)} Community{" "}
+            {numCommunity === 1 ? "match" : "matches"}.
+          </Text>
+          <Button
+            colorScheme="blue"
+            onClick={() => setCurrentTab(1)}
+            data-test="Switch To Community Tab"
+          >
+            Switch to Community tab
+          </Button>
+        </VStack>
+      );
+    }
+    return "No Matches Found!";
+  }, [totalCount.numCommunity, setCurrentTab]);
+
+  const searchedEmptyMessage = useMemo(() => {
+    const numCurated = totalCount.numCurated ?? 0;
+    if (numCurated > 0) {
+      return (
+        <VStack spacing={4} data-test="Community Empty With Curated Results">
+          <Text fontSize="36pt">No Community Matches Found!</Text>
+          <Text fontSize="16pt">
+            There {numCurated === 1 ? "is" : "are"} {intWithCommas(numCurated)}{" "}
+            Curated {numCurated === 1 ? "match" : "matches"}.
+          </Text>
+          <Button
+            colorScheme="blue"
+            onClick={() => setCurrentTab(0)}
+            data-test="Switch To Curated Tab"
+          >
+            Switch to Curated tab
+          </Button>
+        </VStack>
+      );
+    }
+    return "No Matches Found!";
+  }, [totalCount.numCurated, setCurrentTab]);
+
   const curatedContentDisplay = useMemo(
     () =>
       curatedContent
-        ? displayMatchingContent(curatedContent, {
-            base: `calc(100vh - ${q ? "250" : "210"}px)`,
-            lg: `calc(100vh - ${q ? "210" : "170"}px)`,
-          })
+        ? displayMatchingContent(
+            curatedContent,
+            {
+              base: `calc(100vh - ${q ? "250" : "210"}px)`,
+              lg: `calc(100vh - ${q ? "210" : "170"}px)`,
+            },
+            curatedEmptyMessage,
+          )
         : null,
-    [displayMatchingContent, curatedContent, q],
+    [displayMatchingContent, curatedContent, q, curatedEmptyMessage],
   );
 
   const trendingContentDisplay = useMemo(
@@ -322,12 +373,16 @@ export function Explore() {
   const searchedContentDisplay = useMemo(
     () =>
       searchedContent
-        ? displayMatchingContent(searchedContent, {
-            base: `calc(100vh - ${q ? "250" : "210"}px)`,
-            lg: `calc(100vh - ${q ? "210" : "170"}px)`,
-          })
+        ? displayMatchingContent(
+            searchedContent,
+            {
+              base: `calc(100vh - ${q ? "250" : "210"}px)`,
+              lg: `calc(100vh - ${q ? "210" : "170"}px)`,
+            },
+            searchedEmptyMessage,
+          )
         : null,
-    [displayMatchingContent, searchedContent, q],
+    [displayMatchingContent, searchedContent, q, searchedEmptyMessage],
   );
 
   // TODO: figure out functions inside hooks
@@ -335,6 +390,7 @@ export function Explore() {
   function displayMatchingContent(
     matches: Content[],
     minHeight?: string | { base: string; lg: string },
+    emptyMessage?: React.ReactNode,
   ) {
     const cardContent: CardContent[] = matches.map((itemObj) => {
       const { contentId, owner, type: contentType } = itemObj;
@@ -369,7 +425,7 @@ export function Explore() {
           showActivityCategories={true}
           showOwnerName={true}
           cardContent={cardContent}
-          emptyMessage={"No Matches Found!"}
+          emptyMessage={emptyMessage ?? "No Matches Found!"}
           includeSelectionBox={user ? true : false}
           selectedCards={cardSelections.ids}
           onCardSelected={cardSelections.add}

--- a/apps/app/src/widgets/CardList.tsx
+++ b/apps/app/src/widgets/CardList.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import { ReactElement, ReactNode } from "react";
 import { Text, Icon, Box, Flex } from "@chakra-ui/react";
 import Card, { CardContent } from "./Card";
 import { MdInfoOutline } from "react-icons/md";
@@ -33,7 +33,7 @@ export default function CardList({
   showActivityCategories?: boolean;
   showAddButton?: boolean;
   showLibraryEditor?: boolean;
-  emptyMessage: string;
+  emptyMessage: ReactNode;
   includeSelectionBox?: boolean;
   selectedCards?: Set<string>;
   onCardSelected?: (contentId: string) => void;
@@ -59,7 +59,11 @@ export default function CardList({
         borderTop="2px solid gray"
       >
         <Icon fontSize="48pt" as={MdInfoOutline} />
-        <Text fontSize="36pt">{emptyMessage}</Text>
+        {typeof emptyMessage === "string" ? (
+          <Text fontSize="36pt">{emptyMessage}</Text>
+        ) : (
+          emptyMessage
+        )}
       </Flex>
     );
   }

--- a/packages/e2e-tests/e2e/Explore/navigateExplore.cy.ts
+++ b/packages/e2e-tests/e2e/Explore/navigateExplore.cy.ts
@@ -1,4 +1,52 @@
 describe("Navigate Explore Tests", { tags: ["@group3"] }, function () {
+  it("shows helpful message and switch button when curated tab has no matches but community does", () => {
+    cy.loginAsTestUser({ isEditor: true });
+
+    const code = Date.now().toString();
+
+    // Create public (community) content that is NOT published to the library
+    cy.createContent({
+      name: `CommunityOnly${code}`,
+      doenetML: "Community only content",
+      makePublic: true,
+    }).then(() => {
+      cy.visit(`/explore?q=CommunityOnly${code}`);
+
+      // Curated tab should be active with 0 results
+      cy.get('[data-test="Curated Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+
+      // Should show message mentioning community matches, not just "No Matches Found!"
+      cy.get('[data-test="Curated Empty With Community Results"]').should(
+        "be.visible",
+      );
+      cy.get('[data-test="Curated Empty With Community Results"]').should(
+        "contain.text",
+        "No Curated Matches Found!",
+      );
+      cy.get('[data-test="Curated Empty With Community Results"]').should(
+        "contain.text",
+        "Community",
+      );
+
+      // Clicking the switch button should go to the Community tab
+      cy.get('[data-test="Switch To Community Tab"]').click();
+      cy.get('[data-test="Community Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+      cy.get('[data-test="Curated Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "false",
+      );
+    });
+  });
+
   it("remember explore's current tab", () => {
     cy.loginAsTestUser({ isEditor: true });
 


### PR DESCRIPTION
## Summary

Fixes #2771

- When the Curated tab has no matches but the Community tab does, display a context-aware message ("No Curated Matches Found! There are X Community matches.") with a button to switch to the Community tab.
- The reverse is also handled: when the Community (searched) tab has no matches but Curated does, the message directs to the Curated tab.
- Broadens `CardList`'s `emptyMessage` prop from `string` to `ReactNode` to allow richer empty states.

## Test plan

- [ ] Create a public (non-library) activity and search for its unique name on `/explore` — with the Curated tab selected, you should see "No Curated Matches Found!" plus the community count and a "Switch to Community tab" button.
- [ ] Click the "Switch to Community tab" button and verify the Community tab becomes active.
- [ ] Create a library-published activity and search for its unique name on `/explore` — with the Community tab selected and no community matches, you should see "No Community Matches Found!" plus the curated count and a "Switch to Curated tab" button.
- [ ] When both tabs have results (or both are empty), the generic "No Matches Found!" still appears.
- [ ] New Cypress e2e test (`navigateExplore.cy.ts`) covers the curated-empty/community-has-results case.

https://claude.ai/code/session_01URNLszQkbKKoDp7ChRdr88

---
_Generated by [Claude Code](https://claude.ai/code/session_01URNLszQkbKKoDp7ChRdr88)_