### PR TITLE
fix(folder-nav): de-emphasize inactive tabs on small screens

### DIFF
--- a/apps/app/src/paths/FolderContext.cy.tsx
+++ b/apps/app/src/paths/FolderContext.cy.tsx
@@ -1,0 +1,225 @@
+import { FolderContext } from "./FolderContext";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
+import { SiteContext } from "./SiteHeader";
+
+const TEST_USER_ID = "user-abc-123";
+
+const mockContext: SiteContext = {
+  user: {
+    userId: TEST_USER_ID,
+    firstNames: "Test",
+    lastNames: "User",
+    isAnonymous: false,
+    email: null,
+  },
+  exploreTab: null,
+  setExploreTab: () => {},
+  addTo: null,
+  setAddTo: () => {},
+  allLicenses: [],
+  allDoenetmlVersions: [],
+};
+
+/** Wraps FolderContext with a parent that supplies outlet context and a minimal child route. */
+function mountFolderContext(initialPath: string) {
+  function TestParent() {
+    return <Outlet context={mockContext} />;
+  }
+
+  const router = createMemoryRouter(
+    [
+      {
+        element: <TestParent />,
+        children: [
+          {
+            element: <FolderContext />,
+            children: [
+              {
+                path: `/activities/${TEST_USER_ID}`,
+                element: (
+                  <div data-test="outlet-content">Activities Content</div>
+                ),
+              },
+              {
+                path: "/trash",
+                element: <div data-test="outlet-content">Trash Content</div>,
+              },
+              {
+                path: `/sharedWithMe/${TEST_USER_ID}`,
+                element: <div data-test="outlet-content">Shared Content</div>,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    { initialEntries: [initialPath] },
+  );
+
+  cy.mount(<RouterProvider router={router} />);
+}
+
+describe("FolderContext navigation panel", { tags: ["@group1"] }, () => {
+  describe("navigation link rendering", () => {
+    it("renders all three navigation links", () => {
+      mountFolderContext(`/activities/${TEST_USER_ID}`);
+      cy.get('[data-test="My Activities Link"]').should("be.visible");
+      cy.get('[data-test="Shared With Me Button"]').should("be.visible");
+      cy.get('[data-test="Trash Link"]').should("be.visible");
+    });
+
+    it("renders the outlet content", () => {
+      mountFolderContext(`/activities/${TEST_USER_ID}`);
+      cy.get('[data-test="outlet-content"]').should(
+        "contain.text",
+        "Activities Content",
+      );
+    });
+  });
+
+  describe("active tab marking (aria-current)", () => {
+    it("marks My Activities as current when on activities path", () => {
+      mountFolderContext(`/activities/${TEST_USER_ID}`);
+      cy.get('[data-test="My Activities Link"]').should(
+        "have.attr",
+        "aria-current",
+        "page",
+      );
+      cy.get('[data-test="Shared With Me Button"]').should(
+        "not.have.attr",
+        "aria-current",
+      );
+      cy.get('[data-test="Trash Link"]').should(
+        "not.have.attr",
+        "aria-current",
+      );
+    });
+
+    it("marks Trash as current when on trash path", () => {
+      mountFolderContext("/trash");
+      cy.get('[data-test="Trash Link"]').should(
+        "have.attr",
+        "aria-current",
+        "page",
+      );
+      cy.get('[data-test="My Activities Link"]').should(
+        "not.have.attr",
+        "aria-current",
+      );
+      cy.get('[data-test="Shared With Me Button"]').should(
+        "not.have.attr",
+        "aria-current",
+      );
+    });
+
+    it("marks Shared With Me as current when on sharedWithMe path", () => {
+      mountFolderContext(`/sharedWithMe/${TEST_USER_ID}`);
+      cy.get('[data-test="Shared With Me Button"]').should(
+        "have.attr",
+        "aria-current",
+        "page",
+      );
+      cy.get('[data-test="My Activities Link"]').should(
+        "not.have.attr",
+        "aria-current",
+      );
+      cy.get('[data-test="Trash Link"]').should(
+        "not.have.attr",
+        "aria-current",
+      );
+    });
+  });
+
+  describe("small screen: de-emphasize inactive tabs", () => {
+    beforeEach(() => {
+      cy.viewport(375, 667); // small/mobile screen
+    });
+
+    it("active My Activities tab has full opacity; inactive tabs are de-emphasized", () => {
+      mountFolderContext(`/activities/${TEST_USER_ID}`);
+      cy.get('[data-test="My Activities Link"]').should(
+        "have.css",
+        "opacity",
+        "1",
+      );
+      cy.get('[data-test="Trash Link"]').should("have.css", "opacity", "0.5");
+      cy.get('[data-test="Shared With Me Button"]').should(
+        "have.css",
+        "opacity",
+        "0.5",
+      );
+    });
+
+    it("active Trash tab has full opacity; inactive tabs are de-emphasized", () => {
+      mountFolderContext("/trash");
+      cy.get('[data-test="Trash Link"]').should("have.css", "opacity", "1");
+      cy.get('[data-test="My Activities Link"]').should(
+        "have.css",
+        "opacity",
+        "0.5",
+      );
+      cy.get('[data-test="Shared With Me Button"]').should(
+        "have.css",
+        "opacity",
+        "0.5",
+      );
+    });
+
+    it("active Shared With Me tab has full opacity; inactive tabs are de-emphasized", () => {
+      mountFolderContext(`/sharedWithMe/${TEST_USER_ID}`);
+      cy.get('[data-test="Shared With Me Button"]').should(
+        "have.css",
+        "opacity",
+        "1",
+      );
+      cy.get('[data-test="My Activities Link"]').should(
+        "have.css",
+        "opacity",
+        "0.5",
+      );
+      cy.get('[data-test="Trash Link"]').should("have.css", "opacity", "0.5");
+    });
+  });
+
+  describe("medium screen: all tabs have full opacity", () => {
+    beforeEach(() => {
+      cy.viewport(1024, 768); // medium screen (above md breakpoint)
+    });
+
+    it("all tabs have full opacity regardless of active state", () => {
+      mountFolderContext(`/activities/${TEST_USER_ID}`);
+      cy.get('[data-test="My Activities Link"]').should(
+        "have.css",
+        "opacity",
+        "1",
+      );
+      cy.get('[data-test="Trash Link"]').should("have.css", "opacity", "1");
+      cy.get('[data-test="Shared With Me Button"]').should(
+        "have.css",
+        "opacity",
+        "1",
+      );
+    });
+  });
+
+  describe("accessibility", () => {
+    it("passes accessibility on My Activities page", () => {
+      mountFolderContext(`/activities/${TEST_USER_ID}`);
+      cy.wait(100);
+      cy.checkAccessibility("body");
+    });
+
+    it("passes accessibility on Trash page", () => {
+      mountFolderContext("/trash");
+      cy.wait(100);
+      cy.checkAccessibility("body");
+    });
+
+    it("passes accessibility on small screens", () => {
+      cy.viewport(375, 667);
+      mountFolderContext(`/activities/${TEST_USER_ID}`);
+      cy.wait(100);
+      cy.checkAccessibility("body");
+    });
+  });
+});

--- a/apps/app/src/paths/FolderContext.tsx
+++ b/apps/app/src/paths/FolderContext.tsx
@@ -22,6 +22,7 @@ export function FolderContext() {
       flexShrink={0}
       align="flex-start"
       borderRight={{ base: "none", md: "solid 2px black" }}
+      borderBottom={{ base: "solid 2px black", md: "none" }}
       p={{ base: "0px", xl: "10px" }}
       minHeight={{ base: "fit-content", md: "100%" }}
       flexDir={{ base: "row", md: "column" }}
@@ -31,7 +32,10 @@ export function FolderContext() {
         to={activitiesPath}
         variant="ghost"
         justifyContent="flex-start"
-        width={isActivitiesActive ? "100%" : "calc(100% - 4px)"}
+        width={{
+          base: "auto",
+          md: isActivitiesActive ? "100%" : "calc(100% - 4px)",
+        }}
         backgroundColor={
           isActivitiesActive ? "doenet.lightBlue" : "transparent"
         }
@@ -40,9 +44,14 @@ export function FolderContext() {
             ? { backgroundColor: "doenet.lightBlue" }
             : { backgroundColor: "gray.50" }
         }
-        borderLeftWidth={isActivitiesActive ? "4px" : "0"}
-        marginLeft={isActivitiesActive ? "0" : "4px"}
+        borderLeftWidth={{ base: "0", md: isActivitiesActive ? "4px" : "0" }}
+        marginLeft={{ base: "0", md: isActivitiesActive ? "0" : "4px" }}
         borderLeftColor={isActivitiesActive ? "doenet.mainBlue" : "transparent"}
+        borderBottomWidth={{ base: isActivitiesActive ? "3px" : "0", md: "0" }}
+        borderBottomColor={
+          isActivitiesActive ? "doenet.mainBlue" : "transparent"
+        }
+        opacity={{ base: isActivitiesActive ? 1 : 0.5, md: 1 }}
         aria-current={isActivitiesActive ? "page" : undefined}
         data-test="My Activities Link"
       >
@@ -54,7 +63,10 @@ export function FolderContext() {
         to={`/sharedWithMe/${context.user?.userId ?? ""}`}
         variant="ghost"
         justifyContent="flex-start"
-        width={isSharedWithMeActive ? "100%" : "calc(100% - 4px)"}
+        width={{
+          base: "auto",
+          md: isSharedWithMeActive ? "100%" : "calc(100% - 4px)",
+        }}
         backgroundColor={
           isSharedWithMeActive ? "doenet.lightBlue" : "transparent"
         }
@@ -63,11 +75,19 @@ export function FolderContext() {
             ? { backgroundColor: "doenet.lightBlue" }
             : { backgroundColor: "gray.50" }
         }
-        borderLeftWidth={isSharedWithMeActive ? "4px" : "0"}
-        marginLeft={isSharedWithMeActive ? "0" : "4px"}
+        borderLeftWidth={{ base: "0", md: isSharedWithMeActive ? "4px" : "0" }}
+        marginLeft={{ base: "0", md: isSharedWithMeActive ? "0" : "4px" }}
         borderLeftColor={
           isSharedWithMeActive ? "doenet.mainBlue" : "transparent"
         }
+        borderBottomWidth={{
+          base: isSharedWithMeActive ? "3px" : "0",
+          md: "0",
+        }}
+        borderBottomColor={
+          isSharedWithMeActive ? "doenet.mainBlue" : "transparent"
+        }
+        opacity={{ base: isSharedWithMeActive ? 1 : 0.5, md: 1 }}
         aria-current={isSharedWithMeActive ? "page" : undefined}
         data-test="Shared With Me Button"
       >
@@ -82,16 +102,22 @@ export function FolderContext() {
         to={`/trash`}
         variant="ghost"
         justifyContent="flex-start"
-        width={isTrashActive ? "100%" : "calc(100% - 4px)"}
+        width={{
+          base: "auto",
+          md: isTrashActive ? "100%" : "calc(100% - 4px)",
+        }}
         backgroundColor={isTrashActive ? "doenet.lightBlue" : "transparent"}
         _hover={
           isTrashActive
             ? { backgroundColor: "doenet.lightBlue" }
             : { backgroundColor: "gray.50" }
         }
-        borderLeftWidth={isTrashActive ? "4px" : "0"}
-        marginLeft={isTrashActive ? "0" : "4px"}
+        borderLeftWidth={{ base: "0", md: isTrashActive ? "4px" : "0" }}
+        marginLeft={{ base: "0", md: isTrashActive ? "0" : "4px" }}
         borderLeftColor={isTrashActive ? "doenet.mainBlue" : "transparent"}
+        borderBottomWidth={{ base: isTrashActive ? "3px" : "0", md: "0" }}
+        borderBottomColor={isTrashActive ? "doenet.mainBlue" : "transparent"}
+        opacity={{ base: isTrashActive ? 1 : 0.5, md: 1 }}
         aria-current={isTrashActive ? "page" : undefined}
         data-test="Trash Link"
       >

--- a/package-lock.json
+++ b/package-lock.json
@@ -4352,9 +4352,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4367,9 +4364,6 @@
       "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4384,9 +4378,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4399,9 +4390,6 @@
       "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4416,9 +4404,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4431,9 +4416,6 @@
       "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4448,9 +4430,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4463,9 +4442,6 @@
       "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4480,9 +4456,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4495,9 +4468,6 @@
       "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4512,9 +4482,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4528,9 +4495,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4543,9 +4507,6 @@
       "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #2672 — on small screens the folder navigation panel renders as a horizontal row of tabs, but the existing active indicator (a left border) is invisible in that orientation, making it unclear which tab is currently active.

### Changes

- **Bottom border indicator on small screens**: switches the active-tab indicator from `borderLeft` (works in vertical list) to `borderBottom` (correct for horizontal row)
- **De-emphasize inactive tabs**: sets `opacity: 0.5` on inactive tabs at `base` breakpoint so the active tab stands out clearly; reverts to `opacity: 1` at `md+` where a left-border already distinguishes the selection
- **Structural separator**: adds `borderBottom` to the navigation panel itself on small screens (mirrors the `borderRight` already used at `md+`) to visually separate navigation from page content
- **Button width/margin fix**: changes `width` and `marginLeft` to be responsive — `auto` on small screens (correct for a horizontal row) vs. `100%`/`calc(100%-4px)` on `md+` (correct for a vertical list)

### Tests

Adds `FolderContext.cy.tsx` (Cypress component tests, `@group1`):
- Navigation links render and outlet content is shown
- `aria-current="page"` is set on the active tab and absent from inactive tabs for all three routes
- At mobile viewport (375 px): active tab has `opacity: 1`, inactive tabs have `opacity: 0.5`
- At desktop viewport (1024 px): all tabs have `opacity: 1`
- Accessibility checks pass on activities, trash, and small-screen viewports

## Test plan

- [ ] View the folder navigation on a narrow viewport (< 768 px) — active tab should be clearly highlighted, other tabs visually faded
- [ ] View on a wider viewport (≥ 768 px) — left-border active indicator unchanged
- [ ] CI component tests pass

https://claude.ai/code/session_01J33yqSc58jjoXqENN2bcEs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J33yqSc58jjoXqENN2bcEs)_