### PR TITLE
fix: correct userId corruption when moving shared content to a folder (#2670)

### DIFF
--- a/apps/api/src/query/copy_move.ts
+++ b/apps/api/src/query/copy_move.ts
@@ -884,7 +884,7 @@ export async function getMoveCopyContentData({
         type: true,
         isPublic: true,
         visibility: true,
-        sharedWith: true,
+        sharedWith: { select: { userId: true } },
         parent: {
           select: {
             id: true,

--- a/apps/app/src/popups/MoveCopyContent.cy.tsx
+++ b/apps/app/src/popups/MoveCopyContent.cy.tsx
@@ -444,6 +444,85 @@ describe("MoveCopyContent component tests", { tags: ["@group2"] }, () => {
     cy.get('[data-test="Current destination"]').should("have.text", "Folder 1");
   });
 
+  it("Go to folder uses correct userId even when content is shared with others", () => {
+    // This test checks that the userId prop is not corrupted by the shareAlert computation
+    // when source content is shared with users and the destination folder also has shared users.
+    const sharedUserId = "sharedUser123";
+
+    const mockFetcherSuccess = {
+      state: "idle",
+      formData: undefined,
+      data: { status: 200 },
+      Form: ({ children }: any) => <form>{children}</form>,
+      submit: () => {},
+      load: () => {},
+    } as unknown as FetcherWithComponents<any>;
+
+    // The modal opens showing the shared folder as the destination
+    // (simulating the user having navigated to this folder before the move completed)
+    cy.intercept("/api/copyMove/getMoveCopyContentData/*", {
+      parent: {
+        id: "hij",
+        name: "Shared Folder",
+        type: "folder",
+        isPublic: false,
+        sharedWith: [{ userId: sharedUserId }],
+        parent: null,
+      },
+      contents: [],
+    }).as("getFolderData");
+
+    const onCloseSpy = cy.spy().as("onClose");
+    const onNavigateSpy = cy.spy().as("onNavigate");
+    cy.mount(
+      <MoveCopyContent
+        isOpen={true}
+        onClose={onCloseSpy}
+        onNavigate={onNavigateSpy}
+        fetcher={mockFetcherSuccess}
+        sourceContent={[
+          {
+            contentId,
+            name: contentName,
+            type: contentType,
+            isPublic: false,
+            isShared: true,
+            sharedWith: [
+              {
+                userId: sharedUserId,
+                firstNames: "Shared",
+                lastNames: "User",
+                email: "shared@example.com",
+              },
+            ],
+          },
+        ]}
+        userId={"abc123"}
+        currentParentId={null}
+        allowedParentTypes={["folder"]}
+        action="Move"
+      />,
+    );
+
+    // Wait for the API to return the shared folder data
+    cy.wait("@getFolderData");
+
+    // Verify the modal is in the success state showing the destination folder
+    cy.get('[data-test="MoveCopy Body"]').should(
+      "contain.text",
+      "Shared Folder",
+    );
+
+    // Click "Go to folder" and verify it uses the correct userId from the prop (abc123),
+    // not the shared user's ID (sharedUser123)
+    cy.get('[data-test="Go to Destination"]').click();
+
+    cy.get("@onNavigate").should(
+      "have.been.calledWith",
+      `/activities/abc123/hij`,
+    );
+  });
+
   it("different actions show correct heading text", () => {
     cy.intercept("/api/copyMove/getMoveCopyContentData/*", {
       parent: null,

--- a/apps/app/src/popups/MoveCopyContent.tsx
+++ b/apps/app/src/popups/MoveCopyContent.tsx
@@ -33,7 +33,7 @@ type ActiveView = {
     name: string;
     type: ContentType;
     isPublic: boolean;
-    sharedWith: string[];
+    sharedWith: { userId: string }[];
     parent: {
       id: string;
       type: ContentType;
@@ -226,13 +226,13 @@ export function MoveCopyContent({
         (c) => c.sharedWith?.map((user) => user.userId) ?? [],
       );
       const count = new Map<string, number>();
-      for (userId of sourceSharedWith) {
-        count.set(userId, (count.get(userId) || 0) + 1);
+      for (const sharedUserId of sourceSharedWith) {
+        count.set(sharedUserId, (count.get(sharedUserId) || 0) + 1);
       }
       // If the count of that userId is the same as the length of private sources,
       // that means each private source was shared with that userId
       shareAlert = !activeView.parent.sharedWith.every(
-        (user) => count.get(user) === privateSources.length,
+        (share) => count.get(share.userId) === privateSources.length,
       );
     }
   }

--- a/packages/e2e-tests/e2e/Content Lists/move.cy.ts
+++ b/packages/e2e-tests/e2e/Content Lists/move.cy.ts
@@ -113,6 +113,50 @@ describe("Move tests", { tags: ["@group3"] }, () => {
       .should("contain.text", "Document");
   });
 
+  it("Move document into folder and go to destination folder", () => {
+    cy.loginAsTestUser();
+
+    cy.createContent({ name: "Document", contentType: "singleDoc" });
+    cy.createContent({ name: "My Folder", contentType: "folder" });
+
+    cy.visit("/");
+
+    cy.get('[data-test="My Activities"]').click();
+
+    cy.get(`[data-test="Content Card"]`).should("have.length", 2);
+
+    cy.get('[data-test="Card Select"]').eq(0).click();
+    cy.get('[aria-label="Move to"]').click();
+
+    cy.get('[data-test="MoveCopy Heading 2"]').should("have.text", "Document");
+
+    cy.get('[data-test="Select Item Option"]').should("have.length", 2);
+    cy.get('[data-test="Select Item Option"]')
+      .eq(1)
+      .should("have.text", "My Folder")
+      .should("not.be.disabled");
+
+    cy.get('[data-test="Select Item Option"]').eq(1).click();
+    cy.get('[data-test="Current destination"]').should(
+      "have.text",
+      "My Folder",
+    );
+    cy.get('[data-test="Select Item Option"]').should("have.length", 0);
+
+    cy.get('[data-test="Execute MoveCopy Button"]').click();
+    cy.get('[data-test="MoveCopy Body"]').should(
+      "have.text",
+      "1 item moved to: My Folder",
+    );
+    cy.get('[data-test="Go to Destination"]').click();
+
+    cy.get('[data-test="Folder Title"]').should("have.text", "My Folder");
+    cy.get(`[data-test="Content Card"]`).should("have.length", 1);
+    cy.get(`[data-test="Content Card"]`)
+      .eq(0)
+      .should("contain.text", "Document");
+  });
+
   it("Move problem set into sub folder", () => {
     cy.loginAsTestUser();
 


### PR DESCRIPTION
## Summary

Fixes #2670 — "Moving document to another folder and then clicking Open Folder causes error"

### Root Cause

In `MoveCopyContent.tsx`, the `shareAlert` computation contained a `for...of` loop that used the component's `userId` *prop* as the loop variable (without declaring a new `const/let` variable):

```js
for (userId of sourceSharedWith) {  // ← mutates the `userId` parameter!
  count.set(userId, (count.get(userId) || 0) + 1);
}
```

When moving content that was explicitly shared with other users, this loop overwrote the `userId` parameter with the last shared-user's ID. The destination URL was then computed as:

```js
destinationUrl = `/activities/${userId}/${activeView.parent.id}`;
//                              ^^^^^^ wrong user ID!
```

Navigating to `/activities/{wrongUserId}/{folderId}` caused the API to either return `{notMe: true}` (redirecting to Shared Activities) or a 404 if the folder wasn't publicly accessible — showing the error page.

A secondary bug: the `ActiveView.parent.sharedWith` TypeScript type was declared as `string[]`, but `getMoveCopyContentData` returned the full `contentShares` relation (array of objects). This meant the `shareAlert` check `count.get(user)` was comparing a string map key against a whole object, always returning `undefined` and incorrectly triggering share alerts for any shared destination folder.

### Changes

**`apps/app/src/popups/MoveCopyContent.tsx`**
- Change `for (userId of sourceSharedWith)` → `for (const sharedUserId of sourceSharedWith)` to stop corrupting the `userId` prop
- Update `ActiveView.parent.sharedWith` type from `string[]` to `{ userId: string }[]`
- Fix `shareAlert` comparison to use `share.userId` instead of the raw object

**`apps/api/src/query/copy_move.ts`**
- In `getMoveCopyContentData`, narrow `sharedWith: true` to `sharedWith: { select: { userId: true } }` so the response only includes the `userId` field, matching the updated frontend type

**`packages/e2e-tests/e2e/Content Lists/move.cy.ts`**
- Add E2E test: "Move document into folder and go to destination folder" — the scenario described in the issue was not previously covered by any test

**`apps/app/src/popups/MoveCopyContent.cy.tsx`**
- Add component test: "Go to folder uses correct userId even when content is shared with others" — directly verifies the `userId` prop is not corrupted by the loop when shared content is moved to a shared-with folder

## Test plan

- [ ] New E2E test passes: "Move document into folder and go to destination folder"
- [ ] New component test passes: "Go to folder uses correct userId even when content is shared with others"
- [ ] Existing move tests still pass (no regressions)
- [ ] `npm run format && npm run lint` clean

https://claude.ai/code/session_015zUyV9xisamvNrjBnCbQC3

---
_Generated by [Claude Code](https://claude.ai/code/session_015zUyV9xisamvNrjBnCbQC3)_