### PR TITLE
fix: correct requestScrollTo scroll offset calculations

### DIFF
--- a/apps/app/src/paths/AssignmentResponseStudent.tsx
+++ b/apps/app/src/paths/AssignmentResponseStudent.tsx
@@ -233,7 +233,7 @@ export function AssignmentResponseStudent() {
       const targetAbsoluteTop = iframeTop + offset;
 
       scrollingContainer.current.scrollTo({
-        top: targetAbsoluteTop - 0,
+        top: targetAbsoluteTop - 90,
         behavior: "smooth",
       });
     }
@@ -259,6 +259,7 @@ export function AssignmentResponseStudent() {
         doenetML={data.doenetML}
         doenetmlVersion={data.doenetmlVersion}
         requestScrollTo={requestScrollTo}
+        viewerContainerRef={viewerContainer}
       />
     );
   } else {
@@ -348,9 +349,7 @@ export function AssignmentResponseStudent() {
             </GridItem>
           </Grid>
         </GridItem>
-        <GridItem area="centerContent" ref={viewerContainer}>
-          {mainPanel}
-        </GridItem>
+        <GridItem area="centerContent">{mainPanel}</GridItem>
       </Grid>
     </>
   );

--- a/apps/app/src/paths/editor/DocEditorViewMode.tsx
+++ b/apps/app/src/paths/editor/DocEditorViewMode.tsx
@@ -43,7 +43,7 @@ export function DocEditorViewMode() {
       const targetAbsoluteTop = iframeTop + offset;
 
       scrollingContainer.current.scrollTo({
-        top: targetAbsoluteTop - 90,
+        top: targetAbsoluteTop - (parseInt(headerHeight) + 10),
         behavior: "smooth",
       });
     }

--- a/apps/app/src/views/AssignmentItemResponseStudent.tsx
+++ b/apps/app/src/views/AssignmentItemResponseStudent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { RefObject, useEffect, useState } from "react";
 import { DoenetViewer } from "@doenet/doenetml-iframe";
 
 import {
@@ -39,6 +39,7 @@ export function AssignmentItemResponseStudent({
   doenetML,
   doenetmlVersion,
   requestScrollTo,
+  viewerContainerRef,
 }: {
   assignment: {
     name: string;
@@ -70,6 +71,7 @@ export function AssignmentItemResponseStudent({
   doenetML: string;
   doenetmlVersion: DoenetmlVersion;
   requestScrollTo: (_offset: number) => void;
+  viewerContainerRef?: RefObject<HTMLDivElement | null>;
 }) {
   useEffect(() => {
     document.title = `${assignment?.name} - Doenet`;
@@ -372,6 +374,7 @@ export function AssignmentItemResponseStudent({
             overflow="hidden"
           >
             <Box
+              ref={viewerContainerRef}
               minHeight="calc(100vh - 80px)"
               background="var(--canvas)"
               borderWidth="1px"


### PR DESCRIPTION
## Summary

Fixes #2604 — `requestScrollTo` scroll offset calculations were incorrect in two places, causing DoenetML content to scroll to the wrong position when the viewer requests a scroll (e.g., when navigating to an answer or hint).

- **`AssignmentResponseStudent.tsx`**: The `FIXED_OFFSET` was `0` (a placeholder `- 0`) instead of `90`, causing content to scroll too far down. Additionally, the `viewerContainer` ref was attached to the outer `<GridItem area="centerContent">` rather than the actual viewer `Box`, so `getBoundingClientRect().top` measured the wrong element and the scroll target was miscalculated.
- **`AssignmentItemResponseStudent.tsx`**: Added an optional `viewerContainerRef` prop (forwarded to the viewer `Box`) so `AssignmentResponseStudent` can measure the correct element.
- **`DocEditorViewMode.tsx`**: The offset was hardcoded as `90` (matching the normal 80px header + 10px margin), but when `notBrowsable=true` a 40px warning banner is added making `headerHeight="120px"`. The hardcoded value caused the scroll target to land 30px above the visible area. Changed to `parseInt(headerHeight) + 10` to use the dynamic value.

## Test plan

- [ ] Open an assignment as a student, navigate to an item with hints or answer feedback; verify the page scrolls to the correct position
- [ ] Open an assignment response review page (`AssignmentResponseStudent`) and verify scroll-to works
- [ ] Open a document in the editor view mode with a notBrowsable warning banner (set `notBrowsable=true`) and verify scroll-to works correctly with the taller header

## Notes

Cypress component tests could not be run locally (binary unavailable in this environment). TypeScript (`tsc --noEmit`) and ESLint both pass. CI will run the full test suite.

The existing `cy.get("iframe").eq(0).scrollIntoView()` workaround in `assignmentWorkflow.cy.ts` (around lines 364–394) is a separate pre-existing issue related to `@doenet/assignment-viewer` (DoenetActivityViewer) behavior when creating new item attempts — not addressed by this PR.

https://claude.ai/code/session_01JMg997rhUoDWpN7mscG1eJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMg997rhUoDWpN7mscG1eJ)_