### PR TITLE
fix: claude settings once more

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,17 +46,19 @@
   },
   "sandbox": {
     "enabled": true,
-    "mode": "auto-allow",
+    "autoAllowBashIfSandboxed": true,
     "allowUnsandboxedCommands": false,
     "excludedCommands": ["docker"],
-    "allowedDomains": [
-      "registry.npmjs.org",
-      "cdn.jsdelivr.net",
-      "api.github.com",
-      "github.com",
-      "api.cypress.io",
-      "localhost"
-    ],
+    "network": {
+      "allowedDomains": [
+        "registry.npmjs.org",
+        "cdn.jsdelivr.net",
+        "api.github.com",
+        "github.com",
+        "api.cypress.io",
+        "localhost"
+      ]
+    },
     "filesystem": {
       "allowWrite": ["~/.npm/", "~/.cache/prisma/"]
     }


### PR DESCRIPTION
## Summary
- Adjusts `.claude/settings.json` (follow-up to #2934 / #2932).

## Test plan
- [ ] Verify hooks/permissions still behave as expected on a fresh worktree.