### PR TITLE
fix: surface informative 415 for rejected image MIME types

### DIFF
--- a/apps/api/src/media/upload.test.ts
+++ b/apps/api/src/media/upload.test.ts
@@ -38,7 +38,11 @@ async function createUploader() {
   return user;
 }
 import * as s3 from "./s3";
-import { handleUploadImage } from "./upload";
+import {
+  handleUploadError,
+  handleUploadImage,
+  UnsupportedMimeTypeError,
+} from "./upload";
 import {
   ALLOWED_IMAGE_MIME_TYPES,
   MAX_IMAGE_BYTES,
@@ -341,6 +345,24 @@ describe("handleUploadImage", () => {
 
     expect(res.statusCode).toBe(StatusCodes.CREATED);
     expect((res.jsonBody as { name: string }).name).toBe("Lemon");
+  });
+
+  test("415 with allowed list when fileFilter rejects the claimed MIME", () => {
+    const res = mockRes();
+    const next = vi.fn();
+    handleUploadError(
+      new UnsupportedMimeTypeError("image/svg+xml"),
+      mockReq({}),
+      res as unknown as Response,
+      next,
+    );
+    expect(res.statusCode).toBe(StatusCodes.UNSUPPORTED_MEDIA_TYPE);
+    const body = res.jsonBody as { error: string; details: string };
+    expect(body.error).toBe("Unsupported image type");
+    expect(body.details).toBe(
+      "Allowed: image/jpeg, image/png, image/webp, image/gif",
+    );
+    expect(next).not.toHaveBeenCalled();
   });
 
   test("rolls back the DB row and best-effort deletes S3 when putImage throws", async () => {

--- a/apps/api/src/media/upload.ts
+++ b/apps/api/src/media/upload.ts
@@ -29,6 +29,16 @@ const FORMAT_INFO: Record<string, { mime: string; ext: string }> = {
   gif: { mime: "image/gif", ext: "gif" },
 };
 
+// Thrown by the multer fileFilter so handleUploadError can surface a 415
+// with the actual claimed type and the allowed list, instead of the generic
+// "missing file" fallback that fires when the filter silently drops the file.
+export class UnsupportedMimeTypeError extends Error {
+  constructor(public readonly claimedMimeType: string) {
+    super(`Unsupported image type: ${claimedMimeType}`);
+    this.name = "UnsupportedMimeTypeError";
+  }
+}
+
 export const uploadImageMulter = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: MAX_IMAGE_BYTES, files: 1 },
@@ -38,7 +48,7 @@ export const uploadImageMulter = multer({
     ) {
       cb(null, true);
     } else {
-      cb(null, false);
+      cb(new UnsupportedMimeTypeError(file.mimetype));
     }
   },
 });
@@ -159,6 +169,13 @@ export function handleUploadError(
   res: Response,
   next: (err?: unknown) => void,
 ) {
+  if (err instanceof UnsupportedMimeTypeError) {
+    res.status(StatusCodes.UNSUPPORTED_MEDIA_TYPE).json({
+      error: "Unsupported image type",
+      details: `Allowed: ${ALLOWED_IMAGE_MIME_TYPES.join(", ")}`,
+    });
+    return;
+  }
   if (err instanceof multer.MulterError) {
     if (err.code === "LIMIT_FILE_SIZE") {
       res.status(StatusCodes.REQUEST_TOO_LONG).json({


### PR DESCRIPTION
## Summary
- `apps/api/src/media/upload.ts`: replace the silent `cb(null, false)` in the multer `fileFilter` with a typed `UnsupportedMimeTypeError`, and have `handleUploadError` map it to a 415 carrying the allowed-MIME list in `details`.
- Frontend already surfaces `err.response.data.details` in its toast, so unsupported uploads (SVG, HEIC, PDF, raw, …) now produce a useful "Allowed: image/jpeg, image/png, image/webp, image/gif" message with no client changes.

Closes #2940

## Test plan
- [x] `npx vitest run src/media/upload.test.ts` — new test covering `handleUploadError` for the unsupported-MIME case passes; remaining failures in the file are pre-existing and only happen when `DATABASE_URL` is unset.
- [x] `npx tsc --noEmit` clean.
- [ ] Manual: upload an SVG/HEIC via the UI and confirm the toast shows the allowed list instead of the generic message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)