### PR TITLE
fix(ui): stretch NameBar in folder view flex column

### DIFF
--- a/apps/app/src/widgets/NameBar.tsx
+++ b/apps/app/src/widgets/NameBar.tsx
@@ -52,7 +52,7 @@ export function NameBar({
   if (!isEditable || contentId === null || !fetcher) {
     // Read-only header for root folder: icon sits inside the title box (non-editable)
     return (
-      <Box position="relative" maxWidth={maxWidth} width={width}>
+      <Box position="relative" maxWidth={maxWidth} width={width} flex={1}>
         <Show above="md">
           <Box
             position="absolute"
@@ -98,7 +98,7 @@ export function NameBar({
   }
 
   return (
-    <Box position="relative" maxWidth={maxWidth} width={width}>
+    <Box position="relative" maxWidth={maxWidth} width={width} flex={1}>
       <Show above="md">
         <Box
           position="absolute"
@@ -118,6 +118,7 @@ export function NameBar({
         value={name}
         width={width}
         maxWidth={maxWidth}
+        flex={1}
         fontWeight="bold"
         fontSize={fontSizeMode === "folder" ? "xl" : undefined}
         textAlign="left"


### PR DESCRIPTION
## Problem
In the **folder view** page, the NameBar (gray title bar) collapsed to the width of its text instead of stretching to fill its row like it does on the **editor** page.

## Fix
`NameBar.tsx` already set `width: 100%`, which stretched it inside the editor's `<HStack>` but not inside the folder view's `<Flex flexDirection={{ base: "column", md: "row" }}>` (parent doesn't constrain a definite width on the cross axis when its own width is content-driven). Added `flex={1}` to the outer Box (both read-only and editable branches) and the inner `Editable` so it fills available row/column space in both flex contexts.

## Test plan
- [x] Existing `NameBar.cy.tsx` component tests still pass (15/15)
- [ ] Visual check in folder view: NameBar fills the row
- [ ] Visual check in editor: NameBar still looks right (no regression)

> Note: I couldn't perform the visual checks in this sandbox — the dev MySQL container wasn't reachable from here, so I couldn't bring up the dev server. The change is minimal and isolated to one component; a quick local spin-up should confirm.