### PR TITLE
infra: bump prod container memory and max count

### DIFF
--- a/infra/cloudformation/prod-doenet.params
+++ b/infra/cloudformation/prod-doenet.params
@@ -69,7 +69,7 @@
   },
   {
     "ParameterKey": "ContainerMemory",
-    "ParameterValue": "4096"
+    "ParameterValue": "6144"
   },
   {
     "ParameterKey": "ContainerCpu",
@@ -81,7 +81,7 @@
   },
   {
     "ParameterKey": "MaxCount",
-    "ParameterValue": "1"
+    "ParameterValue": "2"
   },
   {
     "ParameterKey": "MinCount",


### PR DESCRIPTION
## Summary
- Raises `ContainerMemory` from 4096 → 6144 MB and `MaxCount` from 1 → 2 in `prod-doenet.params` so the prod API has more headroom and can scale to a second task under load.

## Test plan
- [x] Apply the params to the prod CloudFormation stack and verify the ECS service updates without disruption.
- [x] Confirm task memory reservation and desired/max count reflect the new values in the ECS console.