### PR TITLE
infra: silence nag when dev3 lights are off

### DIFF
--- a/infra/cloudformation/service.yml
+++ b/infra/cloudformation/service.yml
@@ -991,6 +991,8 @@ Resources:
               MinCapacity=0,
               RoleARN='arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService'
             )
+            cw = boto3.client('cloudwatch', region_name='us-east-1')
+            cw.disable_alarm_actions(AlarmNames=['${EnvironmentName}-${ServiceName}-HealthCheck-Extended-Alarm'])
             ssm.put_parameter(Name=lightsParam, Value='off', Overwrite=True)
 
           def routeTrafficToLightsOnLambda() :
@@ -1091,6 +1093,8 @@ Resources:
               MinCapacity=${MinCount},
               RoleARN='arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService'
             )
+            cw = boto3.client('cloudwatch', region_name='us-east-1')
+            cw.enable_alarm_actions(AlarmNames=['${EnvironmentName}-${ServiceName}-HealthCheck-Extended-Alarm'])
             ssm.put_parameter(Name=lightsParam, Value='on', Overwrite=True)
 
           def serviceIsReady() :
@@ -1233,6 +1237,8 @@ Resources:
                   - "elasticloadbalancing:DescribeTargetHealth"
                   - "ssm:PutParameter"
                   - "ssm:GetParameter"
+                  - "cloudwatch:DisableAlarmActions"
+                  - "cloudwatch:EnableAlarmActions"
                 Resource: "*"
 
   UserPool:

--- a/infra/cloudformation/service.yml
+++ b/infra/cloudformation/service.yml
@@ -991,8 +991,8 @@ Resources:
               MinCapacity=0,
               RoleARN='arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService'
             )
-            cw = boto3.client('cloudwatch', region_name='us-east-1')
-            cw.disable_alarm_actions(AlarmNames=['${EnvironmentName}-${ServiceName}-HealthCheck-Extended-Alarm'])
+            events = boto3.client('events', region_name='us-east-1')
+            events.disable_rule(Name='${EnvironmentName}-${ServiceName}-nag-extended-alarms')
             ssm.put_parameter(Name=lightsParam, Value='off', Overwrite=True)
 
           def routeTrafficToLightsOnLambda() :
@@ -1093,8 +1093,8 @@ Resources:
               MinCapacity=${MinCount},
               RoleARN='arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService'
             )
-            cw = boto3.client('cloudwatch', region_name='us-east-1')
-            cw.enable_alarm_actions(AlarmNames=['${EnvironmentName}-${ServiceName}-HealthCheck-Extended-Alarm'])
+            events = boto3.client('events', region_name='us-east-1')
+            events.enable_rule(Name='${EnvironmentName}-${ServiceName}-nag-extended-alarms')
             ssm.put_parameter(Name=lightsParam, Value='on', Overwrite=True)
 
           def serviceIsReady() :
@@ -1237,8 +1237,8 @@ Resources:
                   - "elasticloadbalancing:DescribeTargetHealth"
                   - "ssm:PutParameter"
                   - "ssm:GetParameter"
-                  - "cloudwatch:DisableAlarmActions"
-                  - "cloudwatch:EnableAlarmActions"
+                  - "events:DisableRule"
+                  - "events:EnableRule"
                 Resource: "*"
 
   UserPool:


### PR DESCRIPTION
## Summary
When the dev3 service is scaled to zero by the lights-out flow, the Route53 health-check alarm predictably transitions to ALARM and — because it matches the `${env}-${service}-*-Extended-*` wildcard — triggers the nag pipeline (EventBridge → Step Function → SNS `critical` topic → 5-minute re-page loop). This PR gates that pipeline on lights state so scheduled downtime doesn't page on-call.

## What changed
- **`LightsOut` lambda** now calls `events.disable_rule` (in us-east-1) on the `${env}-${service}-nag-extended-alarms` EventBridge rule — the rule that forwards alarm state-change events from us-east-1 to the us-east-2 default event bus. Once disabled, no state-change events reach `NagStateMachine`, so no SNS notifications fire.
- **`LightsOn` lambda** re-enables the rule.
- Lambda IAM policy gains `events:DisableRule` and `events:EnableRule`.

Silencing at the forwarding-rule level (rather than the alarm's `AlarmActions`) is what actually stops the nag: EventBridge `CloudWatch Alarm State Change` events fire regardless of `ActionsEnabled`, so `DisableAlarmActions` alone would have left the nag intact.

## Test plan
Verified on dev3:
- [x] Rule starts in `ENABLED` (`aws events describe-rule --name dev3-doenet-nag-extended-alarms --region us-east-1`).
- [x] Lights off → LightsOut lambda logs show no IAM errors → rule flips to `DISABLED`.
- [x] Health-check alarm transitions to ALARM as expected, but no new `dev3-nag-state-machine` executions start and no critical SNS notification is delivered.
- [x] Lights on → rule flips back to `ENABLED`, LightsOn lambda logs clean.