### PR TITLE
infra: alarm on ALB target 5XX responses

### DIFF
--- a/infra/cloudformation/service-common.yml
+++ b/infra/cloudformation/service-common.yml
@@ -782,6 +782,26 @@ Resources:
       Type: String
       Value: !Ref NagStateMachine
 
+  Alb5xxAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: LbIsEnabled
+    Properties:
+      AlarmName: !Sub "${EnvironmentName}-ALB-Extended-5XX-Errors"
+      AlarmDescription: ALB is returning 5XX errors
+      Namespace: AWS/ApplicationELB
+      MetricName: HTTPCode_Target_5XX_Count
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt LoadBalancer.LoadBalancerFullName
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref CloudwatchSNSCriticalTopic
+
 Outputs:
   CloudwatchSNSWarningTopic:
     Value: !Ref CloudwatchSNSWarningTopic


### PR DESCRIPTION
## Summary
- Adds an `Alb5xxAlarm` CloudWatch alarm in `service-common.yml` that fires on the ALB's `HTTPCode_Target_5XX_Count` metric (>= 1 over a 1-minute period) and notifies the critical SNS topic.
- Gated on the existing `LbIsEnabled` condition so stacks without a load balancer are unaffected.

## Test plan
- [x] Deploy to dev3 and confirm the alarm resource is created.
- [x] Force a 5XX response from a target (e.g. temporary handler) and verify the alarm transitions to ALARM and the SNS notification is delivered.
- [x] Confirm normal 2xx traffic keeps the alarm in OK.