### PR TITLE
fix(sharing): use folder link for Copy link on folders

### DIFF
--- a/apps/api/src/query/editor.ts
+++ b/apps/api/src/query/editor.ts
@@ -27,6 +27,7 @@ import {
   InvalidRequestError,
   PermissionDeniedRedirectError,
 } from "../utils/error";
+import { fromUUID } from "../utils/uuid";
 import { StatusCodes } from "http-status-codes";
 import { getPublicShareViolations, type PublicShareIssue } from "../access";
 
@@ -376,6 +377,7 @@ export async function getEditorShareStatus({
     },
     select: {
       type: true,
+      ownerId: true,
       isPublic: true,
       visibility: true,
       sharedWith: {
@@ -428,6 +430,7 @@ export async function getEditorShareStatus({
 
   return {
     isPublic: results.isPublic,
+    ownerId: fromUUID(results.ownerId),
     visibility: results.visibility,
     parentIsPublic: results.parent?.isPublic ?? false,
     parentVisibility: results.parent?.visibility ?? "private",

--- a/apps/api/src/test/activity.test.ts
+++ b/apps/api/src/test/activity.test.ts
@@ -40,7 +40,7 @@ import {
   getEditorShareStatus,
 } from "../query/editor";
 import { setContentLicense } from "../query/license";
-import { isEqualUUID } from "../utils/uuid";
+import { fromUUID, isEqualUUID } from "../utils/uuid";
 import { Doc } from "../types";
 import {
   InvalidRequestError,
@@ -119,6 +119,7 @@ test("New activity starts out private, then delete it", async () => {
   });
   expect(sharing).eqls({
     isPublic: false,
+    ownerId: fromUUID(userId),
     visibility: "private",
     canSharePublicly: false,
     publicShareIssues: [

--- a/apps/app/src/features/sharing/components/ShareModal.cy.tsx
+++ b/apps/app/src/features/sharing/components/ShareModal.cy.tsx
@@ -24,6 +24,21 @@ describe("ShareModal component tests", { tags: ["@group3"] }, () => {
     parentSharedWith: [],
   };
 
+  // Stub navigator.clipboard.writeText and alias it as "writeTextStub".
+  function stubClipboard() {
+    cy.window().then((win) => {
+      const writeTextStub = cy.stub().as("writeTextStub");
+      if (win.navigator.clipboard && "writeText" in win.navigator.clipboard) {
+        cy.stub(win.navigator.clipboard, "writeText").callsFake(writeTextStub);
+      } else {
+        Object.defineProperty(win.navigator, "clipboard", {
+          value: { writeText: writeTextStub },
+          configurable: true,
+        });
+      }
+    });
+  }
+
   function setupMocks({
     shareStatus = shareStatusData,
     actionHandler,
@@ -595,17 +610,7 @@ describe("ShareModal component tests", { tags: ["@group3"] }, () => {
       },
     });
 
-    const writeTextStub = cy.stub().as("writeTextStub");
-    cy.window().then((win) => {
-      if (win.navigator.clipboard && "writeText" in win.navigator.clipboard) {
-        cy.stub(win.navigator.clipboard, "writeText").callsFake(writeTextStub);
-      } else {
-        Object.defineProperty(win.navigator, "clipboard", {
-          value: { writeText: writeTextStub },
-          configurable: true,
-        });
-      }
-    });
+    stubClipboard();
 
     cy.mount(
       <ShareModal
@@ -636,17 +641,7 @@ describe("ShareModal component tests", { tags: ["@group3"] }, () => {
       },
     });
 
-    const writeTextStub = cy.stub().as("writeTextStub");
-    cy.window().then((win) => {
-      if (win.navigator.clipboard && "writeText" in win.navigator.clipboard) {
-        cy.stub(win.navigator.clipboard, "writeText").callsFake(writeTextStub);
-      } else {
-        Object.defineProperty(win.navigator, "clipboard", {
-          value: { writeText: writeTextStub },
-          configurable: true,
-        });
-      }
-    });
+    stubClipboard();
 
     cy.mount(
       <ShareModal

--- a/apps/app/src/features/sharing/components/ShareModal.cy.tsx
+++ b/apps/app/src/features/sharing/components/ShareModal.cy.tsx
@@ -15,6 +15,7 @@ describe("ShareModal component tests", { tags: ["@group3"] }, () => {
   };
 
   const shareStatusData: SharingData = {
+    ownerId: "mockOwnerId",
     visibility: "private",
     parentVisibility: "private",
     canSharePublicly: true,
@@ -581,6 +582,89 @@ describe("ShareModal component tests", { tags: ["@group3"] }, () => {
       cy.contains("Document link").should("not.exist");
       cy.contains("Embed code").should("not.exist");
       cy.contains("Copy embed code").should("not.exist");
+    });
+  });
+
+  it("copies the shared-activities link for a folder", () => {
+    const mountOptions = setupMocks({
+      shareStatus: {
+        ...shareStatusData,
+        ownerId: "owner-abc",
+        isPublic: false,
+        visibility: "unlisted",
+      },
+    });
+
+    const writeTextStub = cy.stub().as("writeTextStub");
+    cy.window().then((win) => {
+      if (win.navigator.clipboard && "writeText" in win.navigator.clipboard) {
+        cy.stub(win.navigator.clipboard, "writeText").callsFake(writeTextStub);
+      } else {
+        Object.defineProperty(win.navigator, "clipboard", {
+          value: { writeText: writeTextStub },
+          configurable: true,
+        });
+      }
+    });
+
+    cy.mount(
+      <ShareModal
+        contentId={contentId}
+        contentType="folder"
+        modalIsOpen={true}
+        closeModal={cy.spy().as("onClose")}
+      />,
+      mountOptions,
+    );
+
+    cy.contains("Copy link").click();
+
+    cy.window().then((win) => {
+      cy.get("@writeTextStub").should(
+        "have.been.calledWith",
+        `${win.location.origin}/sharedActivities/owner-abc/${contentId}`,
+      );
+    });
+  });
+
+  it("copies the activity-viewer link for a non-folder", () => {
+    const mountOptions = setupMocks({
+      shareStatus: {
+        ...shareStatusData,
+        isPublic: true,
+        visibility: "public",
+      },
+    });
+
+    const writeTextStub = cy.stub().as("writeTextStub");
+    cy.window().then((win) => {
+      if (win.navigator.clipboard && "writeText" in win.navigator.clipboard) {
+        cy.stub(win.navigator.clipboard, "writeText").callsFake(writeTextStub);
+      } else {
+        Object.defineProperty(win.navigator, "clipboard", {
+          value: { writeText: writeTextStub },
+          configurable: true,
+        });
+      }
+    });
+
+    cy.mount(
+      <ShareModal
+        contentId={contentId}
+        contentType="sequence"
+        modalIsOpen={true}
+        closeModal={cy.spy().as("onClose")}
+      />,
+      mountOptions,
+    );
+
+    cy.contains("Copy link").click();
+
+    cy.window().then((win) => {
+      cy.get("@writeTextStub").should(
+        "have.been.calledWith",
+        `${win.location.origin}/activityViewer/${contentId}`,
+      );
     });
   });
 

--- a/apps/app/src/features/sharing/components/ShareModal.tsx
+++ b/apps/app/src/features/sharing/components/ShareModal.tsx
@@ -42,7 +42,11 @@ import {
 } from "react-icons/fi";
 import type { IconType } from "react-icons";
 
-import { editorDiagnosticsUrl, editorUrl } from "../../../utils/url";
+import {
+  contentViewerUrl,
+  editorDiagnosticsUrl,
+  editorUrl,
+} from "../../../utils/url";
 import type { ShareController } from "../hooks/useShareController";
 import { loadShareStatus } from "../loaders";
 import type { PublicShareIssue, SharingData } from "../types";
@@ -368,12 +372,11 @@ function SharePublicly({
   const [pendingVisibilityUpdate, setPendingVisibilityUpdate] =
     useState<Visibility | null>(null);
 
-  // Folders open in the shared-activities browser; other content opens in the
-  // activity viewer. Using the activity-viewer link for a folder 404s.
-  const shareableLink =
-    contentType === "folder"
-      ? `${window.location.origin}/sharedActivities/${ownerId}/${contentId}`
-      : `${window.location.origin}/activityViewer/${contentId}`;
+  const shareableLink = `${window.location.origin}${contentViewerUrl(
+    contentType,
+    contentId,
+    ownerId,
+  )}`;
   const embedCode = `<iframe src="${window.location.origin}/embed/${contentId}" width="100%" height="800" style="border: 0"></iframe>`;
 
   const [copiedShareLink, setCopiedShareLink] = useState(false);

--- a/apps/app/src/features/sharing/components/ShareModal.tsx
+++ b/apps/app/src/features/sharing/components/ShareModal.tsx
@@ -216,6 +216,7 @@ function ShareModalBody({
         publicShareIssues={shareStatus.publicShareIssues}
         contentId={contentId}
         contentType={contentType}
+        ownerId={shareStatus.ownerId}
         closeModal={onClose}
         onVisibilityChange={onVisibilityChange}
         reloadShareStatus={reloadShareStatus}
@@ -343,6 +344,7 @@ function SharePublicly({
   publicShareIssues,
   contentId,
   contentType,
+  ownerId,
   closeModal,
   onVisibilityChange,
   reloadShareStatus,
@@ -354,6 +356,7 @@ function SharePublicly({
   publicShareIssues: PublicShareIssue[];
   contentId: string;
   contentType: ContentType;
+  ownerId: string;
   closeModal: () => void;
   onVisibilityChange?: (visibility: Visibility) => void;
   reloadShareStatus?: () => void;
@@ -365,7 +368,12 @@ function SharePublicly({
   const [pendingVisibilityUpdate, setPendingVisibilityUpdate] =
     useState<Visibility | null>(null);
 
-  const shareableLink = `${window.location.origin}/activityViewer/${contentId}`;
+  // Folders open in the shared-activities browser; other content opens in the
+  // activity viewer. Using the activity-viewer link for a folder 404s.
+  const shareableLink =
+    contentType === "folder"
+      ? `${window.location.origin}/sharedActivities/${ownerId}/${contentId}`
+      : `${window.location.origin}/activityViewer/${contentId}`;
   const embedCode = `<iframe src="${window.location.origin}/embed/${contentId}" width="100%" height="800" style="border: 0"></iframe>`;
 
   const [copiedShareLink, setCopiedShareLink] = useState(false);

--- a/apps/app/src/features/sharing/types.ts
+++ b/apps/app/src/features/sharing/types.ts
@@ -17,6 +17,7 @@ export type PublicShareIssue =
  * and by editor headers that surface public compliance warnings.
  */
 export type SharingData = {
+  ownerId: string;
   visibility: Visibility;
   parentVisibility: Visibility;
   canSharePublicly: boolean;

--- a/apps/app/src/paths/Explore.tsx
+++ b/apps/app/src/paths/Explore.tsx
@@ -45,6 +45,7 @@ import { clearQueryParameter } from "../utils/explore";
 import { FilterPanel } from "../widgets/FilterPanel";
 import { ExploreFilterDrawer } from "../drawers/ExploreFilterDrawer";
 import { menuIcons } from "../utils/activity";
+import { contentViewerUrl } from "../utils/url";
 import { SiteContext } from "./SiteHeader";
 import { AddContentToMenu } from "../popups/AddContentToMenu";
 import { CopyContentAndReportFinish } from "../popups/CopyContentAndReportFinish";
@@ -338,10 +339,7 @@ export function Explore() {
   ) {
     const cardContent: CardContent[] = matches.map((itemObj) => {
       const { contentId, owner, type: contentType } = itemObj;
-      const cardLink =
-        contentType === "folder" && owner != undefined
-          ? `/sharedActivities/${owner.userId}/${contentId}`
-          : `/activityViewer/${contentId}`;
+      const cardLink = contentViewerUrl(contentType, contentId, owner?.userId);
 
       const ownerAvatarName = createNameNoTag(owner!);
       const ownerName = createNameCheckCurateTag(owner!);

--- a/apps/app/src/paths/SharedActivities.tsx
+++ b/apps/app/src/paths/SharedActivities.tsx
@@ -28,6 +28,7 @@ import { DisplayLicenseItem } from "../widgets/Licenses";
 import { ContentInfoDrawer } from "../drawers/ContentInfoDrawer";
 import CardList from "../widgets/CardList";
 import { menuIcons } from "../utils/activity";
+import { contentViewerUrl } from "../utils/url";
 import { SiteContext } from "./SiteHeader";
 import { AddContentToMenu } from "../popups/AddContentToMenu";
 import { CreateContentMenu } from "../dropdowns/CreateContentMenu";
@@ -282,10 +283,11 @@ export function SharedActivities() {
 
     return {
       content: activity,
-      cardLink:
-        activity.type == "folder"
-          ? `/sharedActivities/${activity.ownerId}/${activity.contentId}`
-          : `/activityViewer/${activity.contentId}`,
+      cardLink: contentViewerUrl(
+        activity.type,
+        activity.contentId,
+        activity.ownerId,
+      ),
       menuItems,
     };
   });

--- a/apps/app/src/paths/SharedWithMe.tsx
+++ b/apps/app/src/paths/SharedWithMe.tsx
@@ -10,6 +10,7 @@ import { formatAssignmentBlurb } from "../utils/assignment";
 import { NameBar } from "../widgets/NameBar";
 import { BsPeople } from "react-icons/bs";
 import { createNameNoTag } from "../utils/names";
+import { contentViewerUrl } from "../utils/url";
 import { useCardSelections } from "../hooks/cardSelections";
 
 export async function loader() {
@@ -82,10 +83,11 @@ export function SharedWithMe() {
       cardMenuRefs.current[position] = element;
     };
 
-    const cardLink =
-      activity.type === "folder"
-        ? `/sharedActivities/${activity.ownerId}/${activity.contentId}`
-        : `/activityViewer/${activity.contentId}`;
+    const cardLink = contentViewerUrl(
+      activity.type,
+      activity.contentId,
+      activity.ownerId,
+    );
 
     const ownerName = createNameNoTag(activity.owner!);
 

--- a/apps/app/src/utils/url.ts
+++ b/apps/app/src/utils/url.ts
@@ -25,6 +25,22 @@ export function editorUrl(
   return `/${contentType === "singleDoc" ? "documentEditor" : "compoundEditor"}/${contentId}/${tabPath}${inCurateMode ? "?curate" : ""}`;
 }
 
+/**
+ * The url for viewing this content.
+ * Folders open in the shared-activities browser, which needs the owner id to
+ * build the route; all other content opens in the activity viewer. A folder
+ * without a known owner falls back to the activity viewer.
+ */
+export function contentViewerUrl(
+  contentType: ContentType,
+  contentId: string,
+  ownerId: string | undefined,
+) {
+  return contentType === "folder" && ownerId !== undefined
+    ? `/sharedActivities/${ownerId}/${contentId}`
+    : `/activityViewer/${contentId}`;
+}
+
 export function editorDiagnosticsUrl(
   contentId: string,
   contentType: ContentType,


### PR DESCRIPTION
Fixes #2987

## Problem

Copying the share link for an **unlisted folder** produced a 404. The link was of the form `.../activityViewer/<id>`, which is a route that only serves activities — not folders.

## Root cause

`ShareModal` hard-coded the shareable link to `/activityViewer/${contentId}` for **all** content types. Folders must be opened via `/sharedActivities/${ownerId}/${folderId}` (the same format used everywhere else folder links are generated, e.g. `SharedActivities.tsx`).

The issue also reported that manually rewriting the URL to `.../sharedActivities/<id>` still 404s. That is **not** a real API bug:

- `isOpenableSharedFolder` already permits `unlisted` folders, and
- `updateVisibility` cascades a folder's visibility down to all descendants, so the contents are visible too.

The manual URL 404'd only because it placed the **folder id in the `ownerId` slot** (with no parent segment), so `getUser` on a non-user id threw. The correct two-segment link works.

## Changes

- `getEditorShareStatus` now returns `ownerId` (short URL form via `fromUUID`), needed to build a folder link.
- Added `ownerId` to the `SharingData` type and plumbed it into `SharePublicly`.
- `shareableLink` now builds `/sharedActivities/${ownerId}/${contentId}` for folders and keeps `/activityViewer/${contentId}` for other content.
- Updated the API test fixture and added two `ShareModal.cy.tsx` cases asserting the clipboard receives the correct folder vs. activity URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)