### PR TITLE
feat(infra): /deploy-dev command + dev3 deployment tracking

### DIFF
--- a/.github/workflows/dev-deploy-pr.yml
+++ b/.github/workflows/dev-deploy-pr.yml
@@ -1,10 +1,11 @@
 name: Dev Deploy (PR command)
 
 # Deploy an unmerged PR to the shared dev3 environment by commenting
-# `/deploy-dev` on the PR. Maintainers only.
+# `/deploy-dev` on the PR (no arguments). Maintainers only.
 #
-#   /deploy-dev        deploy refs/pull/<N>/merge  (PR merged into its base — default)
-#   /deploy-dev head   deploy refs/pull/<N>/head   (branch exactly as pushed; use if the PR has conflicts)
+# It deploys refs/pull/<N>/merge — the PR merged into the current tip of `main`
+# — so you always test the PR combined with the latest main, even when the
+# branch itself is behind. A PR with conflicts is blocked with a hint to update.
 #
 # Security notes:
 #   - issue_comment runs this workflow from the default branch, so the trusted
@@ -63,26 +64,23 @@ jobs:
           PR: ${{ github.event.issue.number }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Exact match on the first line only, so ordinary comments that merely
-          # mention the command (e.g. "/deploy-dev worked great") don't deploy,
-          # and startsWith() collisions like "/deploy-development" are rejected.
+          # Exact match on the first line, and the command takes no arguments, so
+          # ordinary comments that merely mention it (e.g. "/deploy-dev worked
+          # great") don't deploy, and collisions like "/deploy-development" are
+          # rejected.
           line="${BODY%%$'\n'*}"
-          read -r cmd arg extra <<<"$line"
+          read -r cmd extra <<<"$line"
           if [[ "$cmd" != "/deploy-dev" ]]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ -n "$extra" || ( -n "$arg" && "$arg" != "head" ) ]]; then
+          if [[ -n "$extra" ]]; then
             gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" \
-              --body "Usage: \`/deploy-dev\` (PR merged into main) or \`/deploy-dev head\` (branch as-is)."
+              --body "Usage: \`/deploy-dev\` — deploys this PR merged into the current \`main\` to dev3. It takes no arguments."
             echo "run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ "$arg" == "head" ]]; then
-            echo "deploy_ref=refs/pull/${PR}/head" >> "$GITHUB_OUTPUT"
-          else
-            echo "deploy_ref=refs/pull/${PR}/merge" >> "$GITHUB_OUTPUT"
-          fi
+          echo "deploy_ref=refs/pull/${PR}/merge" >> "$GITHUB_OUTPUT"
           echo "run=true" >> "$GITHUB_OUTPUT"
 
       - name: Acknowledge the command
@@ -121,9 +119,9 @@ jobs:
             --body "🚫 \`/deploy-dev\` is limited to maintainers with write access — @${ACTOR} isn't authorized."
           exit 1
 
-      - name: Block merge-mode deploy of a conflicted PR
+      - name: Block deploy of a conflicted PR
         id: merge
-        if: steps.cmd.outputs.run == 'true' && steps.check.outputs.authorized == 'true' && endsWith(steps.cmd.outputs.deploy_ref, '/merge')
+        if: steps.cmd.outputs.run == 'true' && steps.check.outputs.authorized == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.issue.number }}
@@ -139,7 +137,7 @@ jobs:
           done
           if [[ "$mergeable" == "false" ]]; then
             gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" \
-              --body "⚠️ This PR has merge conflicts with its base, so \`/deploy-dev\` (which builds the merged result) can't run. Use \`/deploy-dev head\` to deploy the branch as-is."
+              --body "⚠️ This PR can't be merged into \`main\` (conflicts), so \`/deploy-dev\` can't build the merged result. Resolve the conflicts or update your branch with \`main\`, then comment \`/deploy-dev\` again."
             echo "blocked=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/dev-deploy-pr.yml
+++ b/.github/workflows/dev-deploy-pr.yml
@@ -1,10 +1,10 @@
 name: Dev Deploy (PR command)
 
 # Deploy an unmerged PR to the shared dev3 environment by commenting
-# `/deploy-dev3` on the PR. Maintainers only.
+# `/deploy-dev` on the PR. Maintainers only.
 #
-#   /deploy-dev3        deploy refs/pull/<N>/merge  (PR merged into its base — default)
-#   /deploy-dev3 head   deploy refs/pull/<N>/head   (branch exactly as pushed; use if the PR has conflicts)
+#   /deploy-dev        deploy refs/pull/<N>/merge  (PR merged into its base — default)
+#   /deploy-dev head   deploy refs/pull/<N>/head   (branch exactly as pushed; use if the PR has conflicts)
 #
 # Security notes:
 #   - issue_comment runs this workflow from the default branch, so the trusted
@@ -35,7 +35,7 @@ jobs:
     # Only PR comments that start with the command word.
     if: >
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/deploy-dev3')
+      startsWith(github.event.comment.body, '/deploy-dev')
     runs-on: ubuntu-latest
     outputs:
       authorized: ${{ steps.check.outputs.authorized }}
@@ -73,7 +73,7 @@ jobs:
           ACTOR: ${{ github.event.comment.user.login }}
         run: |
           gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" \
-            --body "🚫 \`/deploy-dev3\` is limited to maintainers with write access — @${ACTOR} isn't authorized."
+            --body "🚫 \`/deploy-dev\` is limited to maintainers with write access — @${ACTOR} isn't authorized."
           exit 1
 
       - name: Resolve deploy ref

--- a/.github/workflows/dev-deploy-pr.yml
+++ b/.github/workflows/dev-deploy-pr.yml
@@ -50,7 +50,9 @@ jobs:
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     outputs:
-      authorized: ${{ steps.check.outputs.authorized }}
+      # Single "clear to deploy" signal: a real command, from someone with
+      # write access, whose merged result isn't blocked by conflicts.
+      go: ${{ steps.cmd.outputs.run == 'true' && steps.check.outputs.authorized == 'true' && steps.merge.outputs.blocked != 'true' }}
       deploy_ref: ${{ steps.cmd.outputs.deploy_ref }}
       deployment_id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
@@ -119,9 +121,31 @@ jobs:
             --body "🚫 \`/deploy-dev\` is limited to maintainers with write access — @${ACTOR} isn't authorized."
           exit 1
 
+      - name: Block merge-mode deploy of a conflicted PR
+        id: merge
+        if: steps.cmd.outputs.run == 'true' && steps.check.outputs.authorized == 'true' && endsWith(steps.cmd.outputs.deploy_ref, '/merge')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          # GitHub computes mergeability asynchronously, so poll briefly. Only
+          # block when we're sure it's unmergeable; treat "unknown" as proceed
+          # (checkout of refs/pull/N/merge would otherwise fail loudly anyway).
+          mergeable=null
+          for _ in 1 2 3 4 5; do
+            mergeable=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" -q '.mergeable' 2>/dev/null || echo null)
+            [[ "$mergeable" == "true" || "$mergeable" == "false" ]] && break
+            sleep 2
+          done
+          if [[ "$mergeable" == "false" ]]; then
+            gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" \
+              --body "⚠️ This PR has merge conflicts with its base, so \`/deploy-dev\` (which builds the merged result) can't run. Use \`/deploy-dev head\` to deploy the branch as-is."
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Open GitHub deployment
         id: deployment
-        if: steps.cmd.outputs.run == 'true' && steps.check.outputs.authorized == 'true'
+        if: steps.cmd.outputs.run == 'true' && steps.check.outputs.authorized == 'true' && steps.merge.outputs.blocked != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.issue.number }}
@@ -150,7 +174,7 @@ jobs:
 
   deploy-backend:
     needs: gate
-    if: needs.gate.outputs.authorized == 'true'
+    if: needs.gate.outputs.go == 'true'
     uses: ./.github/workflows/reusable-deploy-backend.yml
     with:
       deploy_ref: ${{ needs.gate.outputs.deploy_ref }}
@@ -165,7 +189,7 @@ jobs:
 
   deploy-frontend:
     needs: gate
-    if: needs.gate.outputs.authorized == 'true'
+    if: needs.gate.outputs.go == 'true'
     uses: ./.github/workflows/reusable-deploy-frontend.yml
     with:
       deploy_ref: ${{ needs.gate.outputs.deploy_ref }}
@@ -178,7 +202,7 @@ jobs:
 
   deploy-site:
     needs: gate
-    if: needs.gate.outputs.authorized == 'true'
+    if: needs.gate.outputs.go == 'true'
     uses: ./.github/workflows/reusable-deploy-site.yml
     with:
       deploy_ref: ${{ needs.gate.outputs.deploy_ref }}
@@ -191,7 +215,7 @@ jobs:
 
   notify:
     needs: [gate, deploy-backend, deploy-frontend, deploy-site]
-    if: always() && needs.gate.outputs.authorized == 'true'
+    if: always() && needs.gate.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       # Read-only creds so we can ask whether dev3 is actually awake before

--- a/.github/workflows/dev-deploy-pr.yml
+++ b/.github/workflows/dev-deploy-pr.yml
@@ -12,6 +12,10 @@ name: Dev Deploy (PR command)
 #   - The commenter's repo permission is checked before anything runs.
 #   - The comment body is only ever read via an env var, never interpolated
 #     into a shell script, to avoid command injection.
+#   - HOWEVER: deploying builds and runs the PR's OWN code (its Dockerfile and
+#     npm build scripts) on a runner that has dev3's AWS credentials in scope.
+#     Deploying an external contributor's PR = running their code with those
+#     creds. Only run /deploy-dev on a PR whose code you have reviewed/trust.
 
 on:
   issue_comment:
@@ -25,24 +29,62 @@ permissions:
   deployments: write
 
 # Share dev3's single deploy slot with the push/dispatch workflow so a PR test
-# and a main deploy can't run against dev3 at the same time.
+# and a main deploy can't run against dev3 at the same time. Do NOT cancel in
+# progress: this workflow is triggered by comments from anyone on a public repo,
+# and cancelling would let a drive-by commenter kill an in-flight deploy before
+# the auth check runs. Unauthorized comments queue briefly, then fail auth and
+# release the slot. (A push to `main` still preempts, via dev-deploy.yml.)
 concurrency:
   group: dev-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   gate:
-    # Only PR comments that start with the command word.
+    # Cheap pre-filter: a PR comment that starts with the command word, from a
+    # repo insider. This keeps drive-by comments from public users out of the
+    # shared concurrency group entirely. The authoritative permission check
+    # (write access) still runs below — author_association is only a filter.
     if: >
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/deploy-dev')
+      startsWith(github.event.comment.body, '/deploy-dev') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     outputs:
       authorized: ${{ steps.check.outputs.authorized }}
-      deploy_ref: ${{ steps.ref.outputs.deploy_ref }}
+      deploy_ref: ${{ steps.cmd.outputs.deploy_ref }}
       deployment_id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
+      - name: Parse command
+        id: cmd
+        env:
+          BODY: ${{ github.event.comment.body }}
+          PR: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Exact match on the first line only, so ordinary comments that merely
+          # mention the command (e.g. "/deploy-dev worked great") don't deploy,
+          # and startsWith() collisions like "/deploy-development" are rejected.
+          line="${BODY%%$'\n'*}"
+          read -r cmd arg extra <<<"$line"
+          if [[ "$cmd" != "/deploy-dev" ]]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -n "$extra" || ( -n "$arg" && "$arg" != "head" ) ]]; then
+            gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" \
+              --body "Usage: \`/deploy-dev\` (PR merged into main) or \`/deploy-dev head\` (branch as-is)."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$arg" == "head" ]]; then
+            echo "deploy_ref=refs/pull/${PR}/head" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy_ref=refs/pull/${PR}/merge" >> "$GITHUB_OUTPUT"
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
       - name: Acknowledge the command
+        if: steps.cmd.outputs.run == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           COMMENT_ID: ${{ github.event.comment.id }}
@@ -53,6 +95,7 @@ jobs:
 
       - name: Check commenter permission
         id: check
+        if: steps.cmd.outputs.run == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           ACTOR: ${{ github.event.comment.user.login }}
@@ -66,7 +109,7 @@ jobs:
           fi
 
       - name: Reject unauthorized commenter
-        if: steps.check.outputs.authorized != 'true'
+        if: steps.cmd.outputs.run == 'true' && steps.check.outputs.authorized != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.issue.number }}
@@ -76,22 +119,9 @@ jobs:
             --body "🚫 \`/deploy-dev\` is limited to maintainers with write access — @${ACTOR} isn't authorized."
           exit 1
 
-      - name: Resolve deploy ref
-        id: ref
-        env:
-          BODY: ${{ github.event.comment.body }}
-          PR: ${{ github.event.issue.number }}
-        run: |
-          # Second whitespace-delimited token of the first line selects the ref kind.
-          arg=$(printf '%s' "$BODY" | awk 'NR==1 {print $2}')
-          if [[ "$arg" == "head" ]]; then
-            echo "deploy_ref=refs/pull/${PR}/head" >> "$GITHUB_OUTPUT"
-          else
-            echo "deploy_ref=refs/pull/${PR}/merge" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Open GitHub deployment
         id: deployment
+        if: steps.cmd.outputs.run == 'true' && steps.check.outputs.authorized == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.issue.number }}

--- a/.github/workflows/dev-deploy-pr.yml
+++ b/.github/workflows/dev-deploy-pr.yml
@@ -164,25 +164,55 @@ jobs:
     if: always() && needs.gate.outputs.authorized == 'true'
     runs-on: ubuntu-latest
     steps:
+      # Read-only creds so we can ask whether dev3 is actually awake before
+      # claiming a deployment is live. Best-effort: never fails the job.
+      - name: Configure AWS credentials
+        id: aws
+        if: needs.gate.outputs.deployment_id != ''
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          audience: sts.amazonaws.com
+          role-to-assume: arn:aws:iam::568298704244:role/github-actions-dev3
+          role-session-name: dev3-deploy-status
+          aws-region: us-east-2
+
       - name: Finalize GitHub deployment status
         if: needs.gate.outputs.deployment_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
           ID: ${{ needs.gate.outputs.deployment_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HAVE_AWS: ${{ steps.aws.outcome }}
           B: ${{ needs.deploy-backend.result }}
           F: ${{ needs.deploy-frontend.result }}
           S: ${{ needs.deploy-site.result }}
         run: |
           if [[ "$B" == "success" && "$F" == "success" && "$S" == "success" ]]; then
-            state=success
+            # dev3 scales to zero on the lights-out schedule (and the backend
+            # deploy is a no-op while it's asleep), so reflect whether it's
+            # actually serving rather than always claiming success.
+            lights=unknown
+            if [[ "$HAVE_AWS" == "success" ]]; then
+              lights=$(aws ssm get-parameter --name /dev3/doenet/lights \
+                --query Parameter.Value --output text 2>/dev/null || echo unknown)
+            fi
+            if [[ "$lights" == "off" ]]; then
+              state=inactive
+              desc="dev3 is asleep (lights off); this ref serves on next wake"
+            else
+              state=success
+              desc="deployed to dev3"
+            fi
           else
             state=failure
+            desc="dev3 deploy failed (backend:$B frontend:$F site:$S)"
           fi
-          # On success GitHub auto-inactivates the previous dev3 deployment, so
-          # the Environments tab always reflects what is currently live.
+          # On a success status GitHub auto-inactivates the previous dev3
+          # deployment, so the Environments tab reflects what is currently live.
           gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments/${ID}/statuses" \
             -f state="$state" \
+            -f description="$desc" \
             -f environment=dev3 \
             -f environment_url=https://dev3.doenet.org \
             -f log_url="$RUN_URL" >/dev/null

--- a/.github/workflows/dev-deploy-pr.yml
+++ b/.github/workflows/dev-deploy-pr.yml
@@ -1,0 +1,211 @@
+name: Dev Deploy (PR command)
+
+# Deploy an unmerged PR to the shared dev3 environment by commenting
+# `/deploy-dev3` on the PR. Maintainers only.
+#
+#   /deploy-dev3        deploy refs/pull/<N>/merge  (PR merged into its base — default)
+#   /deploy-dev3 head   deploy refs/pull/<N>/head   (branch exactly as pushed; use if the PR has conflicts)
+#
+# Security notes:
+#   - issue_comment runs this workflow from the default branch, so the trusted
+#     logic and secrets here are never controlled by the PR under test.
+#   - The commenter's repo permission is checked before anything runs.
+#   - The comment body is only ever read via an env var, never interpolated
+#     into a shell script, to avoid command injection.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+  issues: write
+  deployments: write
+
+# Share dev3's single deploy slot with the push/dispatch workflow so a PR test
+# and a main deploy can't run against dev3 at the same time.
+concurrency:
+  group: dev-deploy
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    # Only PR comments that start with the command word.
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/deploy-dev3')
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
+      deploy_ref: ${{ steps.ref.outputs.deploy_ref }}
+      deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+    steps:
+      - name: Acknowledge the command
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api -X POST \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content=eyes >/dev/null
+
+      - name: Check commenter permission
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          perm=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${ACTOR}/permission" -q .permission)
+          echo "Commenter '${ACTOR}' has repo permission '${perm}'."
+          if [[ "$perm" == "admin" || "$perm" == "write" ]]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Reject unauthorized commenter
+        if: steps.check.outputs.authorized != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.issue.number }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" \
+            --body "🚫 \`/deploy-dev3\` is limited to maintainers with write access — @${ACTOR} isn't authorized."
+          exit 1
+
+      - name: Resolve deploy ref
+        id: ref
+        env:
+          BODY: ${{ github.event.comment.body }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          # Second whitespace-delimited token of the first line selects the ref kind.
+          arg=$(printf '%s' "$BODY" | awk 'NR==1 {print $2}')
+          if [[ "$arg" == "head" ]]; then
+            echo "deploy_ref=refs/pull/${PR}/head" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy_ref=refs/pull/${PR}/merge" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open GitHub deployment
+        id: deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.issue.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Attribute the deployment to the PR head commit so GitHub links it to
+          # the PR (the built code may be refs/pull/N/merge, but the head SHA is
+          # the real commit that shows up on the PR timeline).
+          # Best-effort: deployment bookkeeping must never block an actual deploy.
+          head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" -q .head.sha 2>/dev/null || true)
+          if [[ -n "$head_sha" ]]; then
+            payload=$(jq -n --arg ref "$head_sha" \
+              '{ref: $ref, environment: "dev3", required_contexts: [], auto_merge: false, description: "dev3 deploy (PR command)"}')
+            id=$(gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments" --input - -q .id <<<"$payload" 2>/dev/null || true)
+          fi
+          if [[ -n "${id:-}" ]]; then
+            echo "deployment_id=$id" >> "$GITHUB_OUTPUT"
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments/${id}/statuses" \
+              -f state=in_progress \
+              -f environment=dev3 \
+              -f environment_url=https://dev3.doenet.org \
+              -f log_url="$RUN_URL" >/dev/null 2>&1 || true
+          else
+            echo "::warning::could not create dev3 deployment record; deploy continues"
+          fi
+
+  deploy-backend:
+    needs: gate
+    if: needs.gate.outputs.authorized == 'true'
+    uses: ./.github/workflows/reusable-deploy-backend.yml
+    with:
+      deploy_ref: ${{ needs.gate.outputs.deploy_ref }}
+      aws_region: us-east-2
+      ecr_repository: dev3/doenet
+      ecs_cluster: dev3
+      ecs_service: doenet-FARGATE
+      gha_role: arn:aws:iam::568298704244:role/github-actions-dev3
+      sns_topic: arn:aws:sns:us-east-2:568298704244:dev3-critical-cloudwatch-notifications
+      tag_name: latest
+    secrets: inherit
+
+  deploy-frontend:
+    needs: gate
+    if: needs.gate.outputs.authorized == 'true'
+    uses: ./.github/workflows/reusable-deploy-frontend.yml
+    with:
+      deploy_ref: ${{ needs.gate.outputs.deploy_ref }}
+      aws_region: us-east-1
+      gha_role: arn:aws:iam::568298704244:role/github-actions-dev3
+      aws_account_id: "568298704244"
+      env_name: dev3
+      build_mode: dev3
+    secrets: inherit
+
+  deploy-site:
+    needs: gate
+    if: needs.gate.outputs.authorized == 'true'
+    uses: ./.github/workflows/reusable-deploy-site.yml
+    with:
+      deploy_ref: ${{ needs.gate.outputs.deploy_ref }}
+      aws_region: us-east-1
+      gha_role: arn:aws:iam::568298704244:role/github-actions-dev3
+      aws_account_id: "568298704244"
+      env_name: dev3
+      build_mode: dev3
+    secrets: inherit
+
+  notify:
+    needs: [gate, deploy-backend, deploy-frontend, deploy-site]
+    if: always() && needs.gate.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize GitHub deployment status
+        if: needs.gate.outputs.deployment_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ID: ${{ needs.gate.outputs.deployment_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          B: ${{ needs.deploy-backend.result }}
+          F: ${{ needs.deploy-frontend.result }}
+          S: ${{ needs.deploy-site.result }}
+        run: |
+          if [[ "$B" == "success" && "$F" == "success" && "$S" == "success" ]]; then
+            state=success
+          else
+            state=failure
+          fi
+          # On success GitHub auto-inactivates the previous dev3 deployment, so
+          # the Environments tab always reflects what is currently live.
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments/${ID}/statuses" \
+            -f state="$state" \
+            -f environment=dev3 \
+            -f environment_url=https://dev3.doenet.org \
+            -f log_url="$RUN_URL" >/dev/null
+
+      - name: Comment result on the PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.issue.number }}
+          REF: ${{ needs.gate.outputs.deploy_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          B: ${{ needs.deploy-backend.result }}
+          F: ${{ needs.deploy-frontend.result }}
+          S: ${{ needs.deploy-site.result }}
+        run: |
+          if [[ "$B" == "success" && "$F" == "success" && "$S" == "success" ]]; then
+            printf '%s\n' \
+              "✅ Deployed \`${REF}\` to **dev3** → https://dev3.doenet.org" \
+              "(first page load wakes it if the lights are off)." \
+              "" \
+              "_dev3 is shared: the next push to \`main\` overwrites this. To restore main:_" \
+              "\`gh workflow run dev-deploy.yml --ref main -f deploy_ref=main\`" > body.md
+          else
+            printf '%s\n' \
+              "❌ dev3 deploy of \`${REF}\` failed (backend: ${B}, frontend: ${F}, site: ${S}). See the [run log](${RUN_URL})." > body.md
+          fi
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body-file body.md

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -13,16 +13,61 @@ on:
 permissions:
   contents: read
   id-token: write
+  deployments: write
 
 concurrency:
   group: dev-deploy
   cancel-in-progress: true
 
 jobs:
+  # Resolve the ref once and open a GitHub deployment so the repo's dev3
+  # Environment always shows what is currently live on dev3.
+  create-deployment:
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_ref: ${{ steps.ref.outputs.deploy_ref }}
+      deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+    steps:
+      - name: Resolve deploy ref
+        id: ref
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_REF: ${{ inputs.deploy_ref }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [[ "$EVENT" == "workflow_dispatch" && -n "$INPUT_REF" ]]; then
+            echo "deploy_ref=$INPUT_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy_ref=$SHA" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open GitHub deployment
+        id: deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ steps.ref.outputs.deploy_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Best-effort: deployment bookkeeping must never block an actual deploy.
+          payload=$(jq -n --arg ref "$REF" \
+            '{ref: $ref, environment: "dev3", required_contexts: [], auto_merge: false, description: "dev3 deploy"}')
+          id=$(gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments" --input - -q .id <<<"$payload" 2>/dev/null || true)
+          if [[ -n "$id" ]]; then
+            echo "deployment_id=$id" >> "$GITHUB_OUTPUT"
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments/${id}/statuses" \
+              -f state=in_progress \
+              -f environment=dev3 \
+              -f environment_url=https://dev3.doenet.org \
+              -f log_url="$RUN_URL" >/dev/null 2>&1 || true
+          else
+            echo "::warning::could not create dev3 deployment record; deploy continues"
+          fi
+
   deploy-backend:
+    needs: create-deployment
     uses: ./.github/workflows/reusable-deploy-backend.yml
     with:
-      deploy_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_ref || github.sha }}
+      deploy_ref: ${{ needs.create-deployment.outputs.deploy_ref }}
       aws_region: us-east-2
       ecr_repository: dev3/doenet
       ecs_cluster: dev3
@@ -33,9 +78,10 @@ jobs:
     secrets: inherit
 
   deploy-frontend:
+    needs: create-deployment
     uses: ./.github/workflows/reusable-deploy-frontend.yml
     with:
-      deploy_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_ref || github.sha }}
+      deploy_ref: ${{ needs.create-deployment.outputs.deploy_ref }}
       aws_region: us-east-1
       gha_role: arn:aws:iam::568298704244:role/github-actions-dev3
       aws_account_id: "568298704244"
@@ -44,12 +90,40 @@ jobs:
     secrets: inherit
 
   deploy-site:
+    needs: create-deployment
     uses: ./.github/workflows/reusable-deploy-site.yml
     with:
-      deploy_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_ref || github.sha }}
+      deploy_ref: ${{ needs.create-deployment.outputs.deploy_ref }}
       aws_region: us-east-1
       gha_role: arn:aws:iam::568298704244:role/github-actions-dev3
       aws_account_id: "568298704244"
       env_name: dev3
       build_mode: dev3
     secrets: inherit
+
+  record-deployment:
+    needs: [create-deployment, deploy-backend, deploy-frontend, deploy-site]
+    if: always() && needs.create-deployment.outputs.deployment_id != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize GitHub deployment status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ID: ${{ needs.create-deployment.outputs.deployment_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          B: ${{ needs.deploy-backend.result }}
+          F: ${{ needs.deploy-frontend.result }}
+          S: ${{ needs.deploy-site.result }}
+        run: |
+          if [[ "$B" == "success" && "$F" == "success" && "$S" == "success" ]]; then
+            state=success
+          else
+            state=failure
+          fi
+          # On success GitHub auto-inactivates the previous dev3 deployment, so
+          # the Environments tab always reflects what is currently live.
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments/${ID}/statuses" \
+            -f state="$state" \
+            -f environment=dev3 \
+            -f environment_url=https://dev3.doenet.org \
+            -f log_url="$RUN_URL" >/dev/null

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -106,24 +106,54 @@ jobs:
     if: always() && needs.create-deployment.outputs.deployment_id != ''
     runs-on: ubuntu-latest
     steps:
+      # Read-only creds so we can ask whether dev3 is actually awake before
+      # claiming a deployment is live. Best-effort: never fails the job.
+      - name: Configure AWS credentials
+        id: aws
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          audience: sts.amazonaws.com
+          role-to-assume: arn:aws:iam::568298704244:role/github-actions-dev3
+          role-session-name: dev3-deploy-status
+          aws-region: us-east-2
+
       - name: Finalize GitHub deployment status
         env:
           GH_TOKEN: ${{ github.token }}
           ID: ${{ needs.create-deployment.outputs.deployment_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HAVE_AWS: ${{ steps.aws.outcome }}
           B: ${{ needs.deploy-backend.result }}
           F: ${{ needs.deploy-frontend.result }}
           S: ${{ needs.deploy-site.result }}
         run: |
           if [[ "$B" == "success" && "$F" == "success" && "$S" == "success" ]]; then
-            state=success
+            # The pipeline succeeded, but dev3 scales to zero on the lights-out
+            # schedule (and the backend deploy is a no-op while it's asleep).
+            # Reflect whether it's actually serving so the tab can't claim a
+            # ref is live while the environment is off.
+            lights=unknown
+            if [[ "$HAVE_AWS" == "success" ]]; then
+              lights=$(aws ssm get-parameter --name /dev3/doenet/lights \
+                --query Parameter.Value --output text 2>/dev/null || echo unknown)
+            fi
+            if [[ "$lights" == "off" ]]; then
+              state=inactive
+              desc="dev3 is asleep (lights off); this ref serves on next wake"
+            else
+              state=success
+              desc="deployed to dev3"
+            fi
           else
             state=failure
+            desc="dev3 deploy failed (backend:$B frontend:$F site:$S)"
           fi
-          # On success GitHub auto-inactivates the previous dev3 deployment, so
-          # the Environments tab always reflects what is currently live.
+          # On a success status GitHub auto-inactivates the previous dev3
+          # deployment, so the Environments tab reflects what is currently live.
           gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments/${ID}/statuses" \
             -f state="$state" \
+            -f description="$desc" \
             -f environment=dev3 \
             -f environment_url=https://dev3.doenet.org \
             -f log_url="$RUN_URL" >/dev/null

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
   push:
-    branches: ["main", "infra/*"]
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/infra/README.md
+++ b/infra/README.md
@@ -8,8 +8,9 @@ https://github.com/aws-cloudformation/cfn-lint
 ## Testing a PR on dev3
 
 Maintainers can deploy an unmerged PR to the shared dev3 environment by
-commenting `/deploy-dev` on it (or `/deploy-dev head` to deploy the branch as
-pushed rather than merged into `main`).
+commenting `/deploy-dev` on it. This deploys the PR merged into the current tip
+of `main`, so you always test it combined with the latest main — even when the
+branch is behind. A PR with conflicts is blocked with a hint to update it first.
 
 > **Caution:** deploying builds and runs the PR's own code (its Dockerfile and
 > npm build scripts) on a runner that has dev3's AWS credentials in scope. Only

--- a/infra/README.md
+++ b/infra/README.md
@@ -9,13 +9,29 @@ https://github.com/aws-cloudformation/cfn-lint
 
 dev3 is a single shared environment. Every deploy (a push to `main`, a
 `Dev Deploy` workflow_dispatch, or a `/deploy-dev` PR command) records a GitHub
-deployment against the `dev3` environment, so the currently-live ref is always
-visible:
+deployment against the `dev3` environment, so the live ref is visible without
+AWS access:
 
-- **Repo → Environments → `dev3`** shows the active deployment and its ref.
-- A PR deployed via `/deploy-dev` shows a deployment marker on the PR itself.
-- From a script: `gh api "repos/Doenet/DoenetApps/deployments?environment=dev3&per_page=1"`.
+- **Repo → Environments → `dev3`** — the authoritative view. GitHub shows the
+  active deployment, its ref, and whether it's currently live or `inactive`
+  (dev3 marks the deployment `inactive` while its lights are off).
+- A PR deployed via `/deploy-dev` also surfaces a deployment marker on the PR.
 
-Because a GitHub environment keeps only one active deployment, this always
-reflects what is serving on https://dev3.doenet.org right now — a PR deploy
-supersedes `main`, and the next push to `main` supersedes the PR.
+Scripting note: the raw deployments list is ordered newest-attempt-first, so
+`deployments?environment=dev3&per_page=1` gives the most recent _attempt_, which
+may be a failed or `inactive` one — not necessarily what's live. To find the
+live ref, take the most recent deployment whose latest status is `success`:
+
+```bash
+repo=Doenet/DoenetApps
+for id in $(gh api "repos/$repo/deployments?environment=dev3&per_page=20" --jq '.[].id'); do
+  if [ "$(gh api "repos/$repo/deployments/$id/statuses?per_page=1" --jq '.[0].state')" = success ]; then
+    gh api "repos/$repo/deployments/$id" --jq '"live on dev3: \(.ref) (\(.sha[0:7]))"'
+    break
+  fi
+done
+```
+
+A PR deploy supersedes `main`, and the next push to `main` supersedes the PR.
+Note this reflects the _ref that was deployed_, not proof the running container
+matches it — a curl-able version endpoint (planned) is the ground-truth check.

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,3 +4,18 @@ To deploy changes to AWS, run the `aws-deploy` script.
 
 To lint CloudFormation templates without deploying them, use `cfn-lint`.
 https://github.com/aws-cloudformation/cfn-lint
+
+## What is currently on dev3?
+
+dev3 is a single shared environment. Every deploy (a push to `main`, a
+`Dev Deploy` workflow_dispatch, or a `/deploy-dev3` PR command) records a GitHub
+deployment against the `dev3` environment, so the currently-live ref is always
+visible:
+
+- **Repo → Environments → `dev3`** shows the active deployment and its ref.
+- A PR deployed via `/deploy-dev3` shows a deployment marker on the PR itself.
+- From a script: `gh api "repos/Doenet/DoenetApps/deployments?environment=dev3&per_page=1"`.
+
+Because a GitHub environment keeps only one active deployment, this always
+reflects what is serving on https://dev3.doenet.org right now — a PR deploy
+supersedes `main`, and the next push to `main` supersedes the PR.

--- a/infra/README.md
+++ b/infra/README.md
@@ -8,12 +8,12 @@ https://github.com/aws-cloudformation/cfn-lint
 ## What is currently on dev3?
 
 dev3 is a single shared environment. Every deploy (a push to `main`, a
-`Dev Deploy` workflow_dispatch, or a `/deploy-dev3` PR command) records a GitHub
+`Dev Deploy` workflow_dispatch, or a `/deploy-dev` PR command) records a GitHub
 deployment against the `dev3` environment, so the currently-live ref is always
 visible:
 
 - **Repo → Environments → `dev3`** shows the active deployment and its ref.
-- A PR deployed via `/deploy-dev3` shows a deployment marker on the PR itself.
+- A PR deployed via `/deploy-dev` shows a deployment marker on the PR itself.
 - From a script: `gh api "repos/Doenet/DoenetApps/deployments?environment=dev3&per_page=1"`.
 
 Because a GitHub environment keeps only one active deployment, this always

--- a/infra/README.md
+++ b/infra/README.md
@@ -5,6 +5,17 @@ To deploy changes to AWS, run the `aws-deploy` script.
 To lint CloudFormation templates without deploying them, use `cfn-lint`.
 https://github.com/aws-cloudformation/cfn-lint
 
+## Testing a PR on dev3
+
+Maintainers can deploy an unmerged PR to the shared dev3 environment by
+commenting `/deploy-dev` on it (or `/deploy-dev head` to deploy the branch as
+pushed rather than merged into `main`).
+
+> **Caution:** deploying builds and runs the PR's own code (its Dockerfile and
+> npm build scripts) on a runner that has dev3's AWS credentials in scope. Only
+> run `/deploy-dev` on a PR whose code you trust — deploying an external
+> contributor's PR means running their code with those credentials.
+
 ## What is currently on dev3?
 
 dev3 is a single shared environment. Every deploy (a push to `main`, a

--- a/infra/cloudformation/dev3-doenet-repositories.params
+++ b/infra/cloudformation/dev3-doenet-repositories.params
@@ -13,6 +13,6 @@
   },
   {
     "ParameterKey": "GitHubRepos",
-    "ParameterValue": "repo:Doenet/DoenetApps:ref:refs/heads/main,repo:Doenet/DoenetApps:ref:refs/heads/infra/*"
+    "ParameterValue": "repo:Doenet/DoenetApps:ref:refs/heads/main"
   }
 ]


### PR DESCRIPTION
Two new things maintainers can do with the shared dev3 environment, plus one behavior change.

## Deploy an open PR to dev3

Comment `/deploy-dev` on any PR to deploy it to dev3. The bot reacts 👀, deploys, and replies with the result. It deploys the PR **merged into the current tip of `main`**, so you always test against the latest main even if the branch is behind — no need to update the branch first. Only maintainers (write access) can trigger it, and it takes no arguments.

If the PR has conflicts with `main`, it's blocked with a hint to update the branch instead.

## See what's currently on dev3

Every dev3 deploy — a merge to `main` or a `/deploy-dev` — now shows up under **Repo → Environments → `dev3`**, which always reflects the ref currently live. A `/deploy-dev` deploy also shows a deployment marker on the PR itself. dev3 shows as `inactive` there while its lights are off.

## `infra/*` branches no longer auto-deploy

Previously, pushing an `infra/*` branch deployed it to dev3. Now that any PR can be deployed on demand, only `main` auto-deploys; everything else goes through `/deploy-dev`.

## Good to know

- **dev3 is shared and single-tenant** — a `/deploy-dev` overwrites whatever's there, and the next merge to `main` overwrites it again.
- **⚠️ Deploying runs the PR's own code** (its Dockerfile/build) with dev3's AWS credentials in scope — only `/deploy-dev` a PR whose code you trust.
- **Effective after this merges** — `/deploy-dev` and the environment tracking run from `main`, so they can't be exercised from this PR; the first real use is the first deploy after it lands.
- The Environments tab records the _ref that was deployed_, not proof the running container matches it — a curl-able version endpoint is a planned follow-up.
- The `infra/*` change includes an OIDC-trust tweak that needs `dev3-doenet-repositories` applied via `aws-deploy` to fully take effect (no functional gap until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
