### PR TITLE
fix(infra): /deploy-dev silently ignored comments with a trailing newline

### DIFF
--- a/.github/workflows/dev-deploy-pr.yml
+++ b/.github/workflows/dev-deploy-pr.yml
@@ -67,8 +67,11 @@ jobs:
           # Exact match on the first line, and the command takes no arguments, so
           # ordinary comments that merely mention it (e.g. "/deploy-dev worked
           # great") don't deploy, and collisions like "/deploy-development" are
-          # rejected.
-          line="${BODY%%$'\n'*}"
+          # rejected. Cut at the first CR as well as LF: GitHub submits comment
+          # bodies with \r\n line endings, and a stray "\r" left on the first
+          # line made the exact match fail silently for any comment with a
+          # trailing newline.
+          line="${BODY%%[$'\r\n']*}"
           read -r cmd extra <<<"$line"
           if [[ "$cmd" != "/deploy-dev" ]]; then
             echo "run=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

Commenting `/deploy-dev` on a PR sometimes does nothing — no 👀 reaction, no error, no deploy. It happened on #2993 ([run 29462923075](https://github.com/Doenet/DoenetApps/actions/runs/29462923075), 6s "success" with all deploy jobs skipped) while an identical-looking comment earlier the same day deployed fine.

## Cause

GitHub submits comment bodies with `\r\n` line endings. The gate's parser cuts the first line at `\n` only:

```bash
line="${BODY%%$'\n'*}"
read -r cmd extra <<<"$line"
if [[ "$cmd" != "/deploy-dev" ]]; then   # cmd is "/deploy-dev\r" → silent no-op
```

So any `/deploy-dev` comment with a trailing newline (e.g. pressing Enter before submitting) reaches the comparison as `/deploy-dev\r` — `read` doesn't strip the `\r` because it isn't IFS whitespace — and is silently treated as a non-command. The run log for the failed attempt shows the trailing newline in the `BODY` env dump.

## Fix

Cut the first line at the first CR *or* LF:

```bash
line="${BODY%%[$'\r\n']*}"
```

Verified against the relevant cases: `/deploy-dev` bare, with `\n`, with `\r\n`, with following lines → deploy; `/deploy-dev args` (with and without CRLF) → usage reply; `/deploy-development`, mid-comment mentions → ignored.

Note: since `issue_comment` workflows run from the default branch, this takes effect once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
