### PR TITLE
feat(media): add image details page

### DIFF
--- a/apps/api/src/media/imageContent.test.ts
+++ b/apps/api/src/media/imageContent.test.ts
@@ -5,7 +5,11 @@ import { setContentLicense } from "../query/license";
 import { setContentIsPublic, shareContentWithEmail } from "../query/share";
 import { createTestUser } from "../test/utils";
 import { InvalidRequestError } from "../utils/error";
-import { createImageContent, deleteImageContent } from "./imageContent";
+import {
+  createImageContent,
+  deleteImageContent,
+  getImageDetails,
+} from "./imageContent";
 
 async function getContent(contentId: Uint8Array) {
   return prisma.content.findUniqueOrThrow({
@@ -283,6 +287,76 @@ describe("createImageContent with storageKey", () => {
 
     const row = await getContent(contentId);
     expect(row.imageData?.storageKey).toBe("images/abc.png");
+  });
+});
+
+describe("getImageDetails", () => {
+  test("returns the image with its source and attribution for the owner", async () => {
+    const owner = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "donut.png",
+      mimeType: "image/png",
+      sizeBytes: 1024,
+      storageKey: "images/abc123",
+      attribution: {
+        imageAuthorName: "Ada",
+        imageAuthorUrl: "https://example.com/ada",
+        imageTitle: "A Donut",
+        imageOriginalUrl: "https://example.com/donut",
+        imageLicenseCodes: "CC-BY-SA",
+        imageLicenseVersion: "4.0",
+      },
+    });
+
+    const { image } = await getImageDetails({
+      contentId,
+      loggedInUserId: owner.userId,
+    });
+
+    expect(image.type).toBe("image");
+    expect(image.name).toBe("donut.png");
+    if (image.type !== "image") throw new Error("expected an image");
+    expect(image.imageSource).toBe("doenet:abc123");
+    expect(image.imageAuthorName).toBe("Ada");
+    expect(image.imageTitle).toBe("A Donut");
+    expect(image.imageLicenseCodes).toBe("CC-BY-SA");
+    expect(image.imageLicenseVersion).toBe("4.0");
+  });
+
+  test("is reachable by a stranger — images are unlisted, not private", async () => {
+    const owner = await createTestUser();
+    const stranger = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "public-ish.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      storageKey: "images/def456",
+    });
+
+    const { image } = await getImageDetails({
+      contentId,
+      loggedInUserId: stranger.userId,
+    });
+
+    expect(image.type).toBe("image");
+    expect(image.name).toBe("public-ish.png");
+  });
+
+  test("throws when the content is not an image", async () => {
+    const owner = await createTestUser();
+    const { contentId: docId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "singleDoc",
+      parentId: null,
+    });
+
+    await expect(
+      getImageDetails({ contentId: docId, loggedInUserId: owner.userId }),
+    ).rejects.toThrow("Content is not an image");
   });
 });
 

--- a/apps/api/src/media/imageContent.ts
+++ b/apps/api/src/media/imageContent.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../model";
 import { prepareNewChild } from "../content-tree";
+import { getContent } from "../query/activity_edit_view";
 import { InvalidRequestError } from "../utils/error";
 
 /**
@@ -111,6 +112,33 @@ export async function createImageContent({
     name: content.name,
     contentType: content.type,
   };
+}
+
+/**
+ * Fetches a single image content item's row (name + attribution + resolvable
+ * source) for the image details page. This serves metadata only — the image
+ * bytes come straight from the CDN, never through the API. Uses the shared
+ * {@link getContent} so the same view-permission rules apply — an image is
+ * `unlisted` (not private), so it's reachable by anyone with the link, the same
+ * reachability the CDN-served bytes already have. Unlike `getActivityViewerData`,
+ * this deliberately skips remix/library lookups, which don't apply to images
+ * (and throw when asked to compile an image as an activity). Throws if
+ * `contentId` isn't an image.
+ */
+export async function getImageDetails({
+  contentId,
+  loggedInUserId = new Uint8Array(16),
+}: {
+  contentId: Uint8Array;
+  loggedInUserId?: Uint8Array;
+}) {
+  const content = await getContent({ contentId, loggedInUserId });
+
+  if (content.type !== "image") {
+    throw new InvalidRequestError("Content is not an image");
+  }
+
+  return { image: content };
 }
 
 export async function deleteImageContent({

--- a/apps/api/src/media/router.ts
+++ b/apps/api/src/media/router.ts
@@ -1,9 +1,12 @@
 import express from "express";
+import { queryOptionalLoggedIn } from "../middleware/queryMiddleware";
+import { contentIdSchema } from "../schemas/contentSchema";
 import {
   handleCompleteUpload,
   handleInitUpload,
   handleSetAttribution,
 } from "./upload";
+import { getImageDetails } from "./imageContent";
 
 export const mediaRouter = express.Router();
 
@@ -15,3 +18,11 @@ mediaRouter.post("/image/complete", handleCompleteUpload);
 
 // Edit the DoenetML `<image>` attribution/licensing on an owned image item.
 mediaRouter.patch("/image/attribution", handleSetAttribution);
+
+// Metadata for the image details page (name + attribution + resolvable source).
+// The `/details` suffix makes clear this returns the row, not the image bytes —
+// the bytes come straight from the CDN, never through this API.
+mediaRouter.get(
+  "/image/:contentId/details",
+  queryOptionalLoggedIn(getImageDetails, contentIdSchema),
+);

--- a/apps/app/src/index.tsx
+++ b/apps/app/src/index.tsx
@@ -125,6 +125,10 @@ import { editorUrl } from "./utils/url";
 import { ScratchPad, loader as scratchPadLoader } from "./paths/ScratchPad";
 import { About } from "./paths/About";
 import { RawViewer, loader as rawViewerLoader } from "./paths/RawViewer";
+import {
+  ImageDetails,
+  loader as imageDetailsLoader,
+} from "./paths/ImageDetails";
 import { GetInvolved } from "./paths/GetInvolved";
 import { Events } from "./paths/Events";
 import { QuickLinks } from "./paths/QuickLinks";
@@ -247,6 +251,12 @@ const router = createBrowserRouter([
         action: genericAction,
         errorElement: <ErrorPage />,
         element: <ActivityViewer />,
+      },
+      {
+        path: "imageDetails/:contentId",
+        loader: imageDetailsLoader,
+        errorElement: <ErrorPage />,
+        element: <ImageDetails />,
       },
       {
         path: "documentEditor/:contentId",

--- a/apps/app/src/paths/Activities.tsx
+++ b/apps/app/src/paths/Activities.tsx
@@ -36,25 +36,14 @@ import {
   useRevalidator,
 } from "react-router";
 import axios from "axios";
-import {
-  MdClose,
-  MdContentCopy,
-  MdOutlineEdit,
-  MdOutlineSearch,
-} from "react-icons/md";
+import { MdClose, MdContentCopy, MdOutlineSearch } from "react-icons/md";
 import { FaPlus } from "react-icons/fa";
 import { LuDessert } from "react-icons/lu";
 
 import { CardContent } from "../widgets/Card";
 import CardList from "../widgets/CardList";
 import { MoveCopyContent } from "../popups/MoveCopyContent";
-import {
-  Content,
-  ContentType,
-  ImageItem,
-  LicenseCode,
-  UserInfo,
-} from "../types";
+import { Content, ContentType, LicenseCode, UserInfo } from "../types";
 import {
   EditImageAttribution,
   emptyImageAttribution,
@@ -154,9 +143,9 @@ export function Activities() {
   // freshly picked file before uploading it (`create`), or to edit an existing
   // image's attribution (`edit`). A license is mandatory in both, so an
   // unlicensed image is never created.
-  const [attributionTarget, setAttributionTarget] = useState<
-    { mode: "create"; file: File } | { mode: "edit"; image: ImageItem } | null
-  >(null);
+  // The image file awaiting a license before its upload completes. Editing the
+  // attribution of an already-uploaded image now lives on the image viewer page.
+  const [uploadTarget, setUploadTarget] = useState<{ file: File } | null>(null);
 
   const { addTo, setAddTo, user } = useOutletContext<SiteContext>();
 
@@ -311,7 +300,7 @@ export function Activities() {
     // No card anchor for the upload flow; clear any stale one so focus restores
     // to the element that had it (rather than an unrelated card's menu button).
     finalFocusRef.current = null;
-    setAttributionTarget({ mode: "create", file });
+    setUploadTarget({ file });
   }
 
   // Runs the two-step upload with the license/attribution the user supplied.
@@ -356,54 +345,21 @@ export function Activities() {
     }
   }
 
-  // Persists edited attribution for an existing image.
-  async function saveImageAttribution(
-    contentId: string,
-    values: ImageAttributionFormValues,
-  ) {
-    await axios.patch("/api/media/image/attribution", { contentId, ...values });
-    revalidator.revalidate();
-  }
-
-  // Maps an existing image's stored fields into the modal's form values.
-  function imageToFormValues(image: ImageItem): ImageAttributionFormValues {
-    return {
-      imageAuthorName: image.imageAuthorName ?? "",
-      imageAuthorUrl: image.imageAuthorUrl ?? "",
-      imageTitle: image.imageTitle ?? "",
-      imageOriginalUrl: image.imageOriginalUrl ?? "",
-      imageLicenseCodes: image.imageLicenseCodes ?? "",
-      imageLicenseVersion:
-        image.imageLicenseVersion ?? emptyImageAttribution.imageLicenseVersion,
-    };
-  }
-
-  const attributionModal = attributionTarget ? (
+  // Shown when the user picks an image to upload: they must license it before
+  // the upload completes. Editing an existing image's attribution happens on the
+  // image viewer page instead.
+  const attributionModal = uploadTarget ? (
     <EditImageAttribution
       isOpen={true}
-      onClose={() => setAttributionTarget(null)}
-      initial={
-        attributionTarget.mode === "edit"
-          ? imageToFormValues(attributionTarget.image)
-          : emptyImageAttribution
-      }
-      imageSource={
-        attributionTarget.mode === "edit"
-          ? attributionTarget.image.imageSource
-          : null
-      }
-      headerLabel={
-        attributionTarget.mode === "edit"
-          ? "Image attribution & license"
-          : "License this image"
-      }
-      submitLabel={attributionTarget.mode === "edit" ? "Save" : "Upload"}
+      onClose={() => setUploadTarget(null)}
+      initial={emptyImageAttribution}
+      imageSource={null}
+      headerLabel="License this image"
+      submitLabel="Upload"
       defaultAuthorName={user ? createNameNoTag(user) : undefined}
       finalFocusRef={finalFocusRef}
       onSubmit={(values) =>
-        attributionTarget.mode === "edit"
-          ? saveImageAttribution(attributionTarget.image.contentId, values)
-          : uploadImageWithAttribution(attributionTarget.file, values)
+        uploadImageWithAttribution(uploadTarget.file, values)
       }
     />
   ) : null;
@@ -826,7 +782,7 @@ export function Activities() {
 
     let cardLink: string | undefined;
     if (activity.type === "image") {
-      cardLink = undefined;
+      cardLink = `/imageDetails/${activity.contentId}`;
     } else if (activity.type === "folder") {
       cardLink = `/activities/${activity.ownerId}/${activity.contentId}`;
     } else if (activity.assignmentInfo) {
@@ -867,19 +823,6 @@ export function Activities() {
             }}
           >
             Copy tag
-          </Button>
-          <Button
-            size="xs"
-            variant="outline"
-            leftIcon={<MdOutlineEdit />}
-            data-test="Edit Image Attribution"
-            onClick={(e) => {
-              // Return focus to this button when the modal closes.
-              finalFocusRef.current = e.currentTarget;
-              setAttributionTarget({ mode: "edit", image: activity });
-            }}
-          >
-            Attribution
           </Button>
         </HStack>
       ) : undefined;

--- a/apps/app/src/paths/ImageDetails.tsx
+++ b/apps/app/src/paths/ImageDetails.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  HStack,
+  Image,
+  Link as ChakraLink,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Tr,
+  useToast,
+  VStack,
+} from "@chakra-ui/react";
+import {
+  MdContentCopy,
+  MdOutlineEdit,
+  MdOutlineImageNotSupported,
+} from "react-icons/md";
+import {
+  useLoaderData,
+  useNavigate,
+  useOutletContext,
+  useRevalidator,
+} from "react-router";
+import axios from "axios";
+import { mediaLicenses } from "@doenet-tools/shared";
+import { ImageItem } from "../types";
+import { resolveImageSource } from "../utils/media";
+import { buildImageTag } from "../utils/imageTag";
+import { WithSideBanners } from "../layout/WithSideBanners";
+import {
+  EditImageAttribution,
+  imageToFormValues,
+  type ImageAttributionFormValues,
+} from "../popups/EditImageAttribution";
+import { SiteContext } from "./SiteHeader";
+import { createNameNoTag } from "../utils/names";
+
+export async function loader({ params }: { params: any }) {
+  const {
+    data: { image },
+  } = await axios.get(`/api/media/image/${params.contentId}/details`);
+
+  return { image: image as ImageItem };
+}
+
+// Map a space-separated `imageLicenseCodes` string onto the human-readable
+// license names DoenetML uses. Unknown codes fall back to the raw code so
+// nothing is silently dropped.
+function licenseNames(codes: string | null | undefined): string {
+  if (!codes) {
+    return "";
+  }
+  return codes
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((code) => {
+      const info = mediaLicenses.find((l) => l.code === code.toUpperCase());
+      return info ? info.name : code;
+    })
+    .join(" + ");
+}
+
+// A single attribution row, rendered only when the value is present. URL
+// values become links so the credit sources stay reachable.
+function AttributionRow({
+  label,
+  value,
+  isUrl = false,
+}: {
+  label: string;
+  value: string | null | undefined;
+  isUrl?: boolean;
+}) {
+  if (!value) {
+    return null;
+  }
+  return (
+    <Tr>
+      <Th
+        width="12rem"
+        verticalAlign="top"
+        textTransform="none"
+        color="gray.600"
+      >
+        {label}
+      </Th>
+      <Td>
+        {isUrl ? (
+          <ChakraLink href={value} isExternal color="blue.600">
+            {value}
+          </ChakraLink>
+        ) : (
+          value
+        )}
+      </Td>
+    </Tr>
+  );
+}
+
+/**
+ * The details page for an uploaded image content item. Uploaded images aren't
+ * editable documents, so clicking one from the activities list opens this page
+ * to show the image together with its DoenetML `<image>` attribution/licensing,
+ * a one-click copy of the tag to paste into a document, and (for the owner) an
+ * attribution editor.
+ */
+export function ImageDetails() {
+  const { image } = useLoaderData() as { image: ImageItem };
+  const { user } = useOutletContext<SiteContext>();
+  const toast = useToast();
+  const navigate = useNavigate();
+  const revalidator = useRevalidator();
+
+  const [editing, setEditing] = useState(false);
+  // Return focus to the Edit button when the modal closes.
+  const editFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    document.title = `${image.name} - Doenet`;
+  }, [image.name]);
+
+  const src = resolveImageSource(image.imageSource);
+  const license = licenseNames(image.imageLicenseCodes);
+  // Only the owner may edit an image's attribution (enforced server-side too).
+  const canEdit = user?.userId === image.ownerId;
+
+  // Persists edited attribution, then reloads the page's loader data so the
+  // shown values (and copied tag) reflect the change.
+  async function saveAttribution(values: ImageAttributionFormValues) {
+    await axios.patch("/api/media/image/attribution", {
+      contentId: image.contentId,
+      ...values,
+    });
+    revalidator.revalidate();
+  }
+
+  const hasAttribution =
+    image.imageTitle ||
+    image.imageAuthorName ||
+    image.imageAuthorUrl ||
+    image.imageOriginalUrl ||
+    license;
+
+  async function copyTag() {
+    const tag = buildImageTag(image);
+    try {
+      await navigator.clipboard.writeText(tag);
+      toast({
+        title: "Image tag copied",
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch {
+      toast({
+        title: "Could not copy to clipboard",
+        description: tag,
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  }
+
+  return (
+    <WithSideBanners bgColor="white" padding="24px">
+      <VStack align="stretch" spacing="20px">
+        <Flex
+          direction={{ base: "column", sm: "row" }}
+          align={{ base: "flex-start", sm: "center" }}
+          justify="space-between"
+          gap="12px"
+        >
+          <Heading size="lg" wordBreak="break-word">
+            {image.name}
+          </Heading>
+          <HStack spacing="8px" flexShrink={0}>
+            <Button
+              leftIcon={<MdContentCopy />}
+              colorScheme="blue"
+              variant="outline"
+              data-test="Copy Image Tag"
+              onClick={copyTag}
+            >
+              Copy tag
+            </Button>
+            {canEdit ? (
+              <Button
+                leftIcon={<MdOutlineEdit />}
+                variant="outline"
+                data-test="Edit Image Attribution"
+                onClick={(e) => {
+                  editFocusRef.current = e.currentTarget;
+                  setEditing(true);
+                }}
+              >
+                Attribution
+              </Button>
+            ) : null}
+          </HStack>
+        </Flex>
+
+        <Box
+          borderWidth="1px"
+          borderColor="gray.200"
+          borderRadius="md"
+          bg="gray.50"
+          p="16px"
+          display="flex"
+          justifyContent="center"
+        >
+          {src ? (
+            <Image
+              src={src}
+              alt={image.imageTitle || image.name}
+              maxW="100%"
+              maxH="70vh"
+              objectFit="contain"
+              data-test="Uploaded Image"
+            />
+          ) : (
+            <VStack color="gray.500" py="40px" spacing="8px">
+              <MdOutlineImageNotSupported size="2.5rem" />
+              <Text>This image isn't available to display yet.</Text>
+            </VStack>
+          )}
+        </Box>
+
+        {hasAttribution ? (
+          <Box>
+            <Heading size="sm" mb="8px">
+              Attribution
+            </Heading>
+            <Table size="sm" variant="simple">
+              <Tbody>
+                <AttributionRow label="Title" value={image.imageTitle} />
+                <AttributionRow label="Author" value={image.imageAuthorName} />
+                <AttributionRow
+                  label="Author URL"
+                  value={image.imageAuthorUrl}
+                  isUrl
+                />
+                <AttributionRow
+                  label="Original URL"
+                  value={image.imageOriginalUrl}
+                  isUrl
+                />
+                <AttributionRow label="License" value={license} />
+                <AttributionRow
+                  label="License version"
+                  value={image.imageLicenseVersion}
+                />
+              </Tbody>
+            </Table>
+          </Box>
+        ) : null}
+
+        <HStack>
+          <Button variant="link" color="blue.600" onClick={() => navigate(-1)}>
+            Back
+          </Button>
+        </HStack>
+      </VStack>
+
+      {canEdit ? (
+        <EditImageAttribution
+          isOpen={editing}
+          onClose={() => setEditing(false)}
+          initial={imageToFormValues(image)}
+          imageSource={image.imageSource}
+          headerLabel="Image attribution & license"
+          submitLabel="Save"
+          defaultAuthorName={user ? createNameNoTag(user) : undefined}
+          finalFocusRef={editFocusRef}
+          onSubmit={saveAttribution}
+        />
+      ) : null}
+    </WithSideBanners>
+  );
+}

--- a/apps/app/src/popups/EditImageAttribution.tsx
+++ b/apps/app/src/popups/EditImageAttribution.tsx
@@ -40,6 +40,7 @@ import {
   type MediaLicenseCode,
 } from "@doenet-tools/shared";
 import { buildImageTag } from "../utils/imageTag";
+import { ImageItem } from "../types";
 
 // The editable attribution fields, as plain form strings ("" when empty). The
 // license is required; the other fields are optional (author is required only
@@ -61,6 +62,22 @@ export const emptyImageAttribution: ImageAttributionFormValues = {
   imageLicenseCodes: "",
   imageLicenseVersion: defaultCreativeCommonsVersion,
 };
+
+// Maps an existing image's stored fields (nullable) into the modal's form
+// values ("" for absent fields), for editing an already-uploaded image.
+export function imageToFormValues(
+  image: ImageItem,
+): ImageAttributionFormValues {
+  return {
+    imageAuthorName: image.imageAuthorName ?? "",
+    imageAuthorUrl: image.imageAuthorUrl ?? "",
+    imageTitle: image.imageTitle ?? "",
+    imageOriginalUrl: image.imageOriginalUrl ?? "",
+    imageLicenseCodes: image.imageLicenseCodes ?? "",
+    imageLicenseVersion:
+      image.imageLicenseVersion ?? emptyImageAttribution.imageLicenseVersion,
+  };
+}
 
 // The handful of licenses most image uploads use, surfaced as one-click cards
 // with plain-language labels and Creative Commons badges. Everything else stays

--- a/apps/app/src/utils/media.ts
+++ b/apps/app/src/utils/media.ts
@@ -12,3 +12,27 @@ const mediaCdnBaseUrl = (
 export const doenetImagesUrl = mediaCdnBaseUrl
   ? `${mediaCdnBaseUrl}/images`
   : undefined;
+
+// The scheme used by the domain-independent image reference stored on content
+// rows (`doenet:<short-uuid>`), mirroring the DoenetML viewer's resolver.
+const doenetSourcePrefix = "doenet:";
+
+/**
+ * Resolves a stored `imageSource` (`doenet:<short-uuid>`) to a browsable CDN
+ * URL — `${doenetImagesUrl}/<short-uuid>` — the same composition the DoenetML
+ * viewer performs at render time. Returns `undefined` when the source is
+ * missing (the S3 PUT hasn't completed), when the CDN base URL isn't configured
+ * for this build, or when the source isn't a `doenet:` reference.
+ */
+export function resolveImageSource(
+  imageSource: string | null | undefined,
+): string | undefined {
+  if (!imageSource || !doenetImagesUrl) {
+    return undefined;
+  }
+  if (!imageSource.startsWith(doenetSourcePrefix)) {
+    return undefined;
+  }
+  const shortUuid = imageSource.slice(doenetSourcePrefix.length);
+  return `${doenetImagesUrl}/${shortUuid}`;
+}


### PR DESCRIPTION
## What & why

Clicking an uploaded image in the activities list previously did nothing. This adds a details page so users can actually **see the image they uploaded**, along with its DoenetML `<image>` attribution/licensing.

## Changes

- **New page** — `/imageDetails/:contentId` (`ImageDetails`): renders the image (resolving the stored `doenet:<short-uuid>` reference against the media CDN), its name, an attribution table, a **Copy tag** button, and an owner-only **attribution editor**. Image cards in the activities list now link here instead of being dead.
- **New API endpoint** — `GET /api/media/image/:contentId/details` (`getImageDetails`): returns the row's **metadata only** — the image bytes still come straight from the CDN, never through the API (the `/details` suffix makes that explicit). It reuses the shared, permission-aware `getContent` and deliberately skips the remix/library lookups that don't apply to images. (The activity-viewer endpoint couldn't be reused: its remix path calls `compileActivityFromContent`, which throws `"No image here"` for image rows.)
- **Moved the edit-attribution dialog** off the activity cards and onto the details page. The cards keep only the upload/license-new-image flow and the copy-tag action.
- Added a `resolveImageSource` helper (`utils/media.ts`) and lifted `imageToFormValues` into `EditImageAttribution` so both call sites share it.

## Notes on reachability

Images are `unlisted` (not `private`), so `getContent`'s existing rules make the metadata link-reachable — the same reachability the CDN-served bytes already have. Attribution editing is owner-only, enforced both in the UI and server-side.

## Testing

- `tsc`, ESLint, and Prettier are clean on all changed files (api + app).
- Added 3 unit tests for `getImageDetails` in `imageContent.test.ts` (owner sees image + attribution; a non-owner can still view; non-image content throws).
- The existing `imageUpload.cy.ts` e2e stays valid (upload/license flow and card copy-tag are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)