### PR TITLE
fix: hoist public content out of unlisted folders in shared activities

### DIFF
--- a/apps/api/src/query/content_list.ts
+++ b/apps/api/src/query/content_list.ts
@@ -412,16 +412,18 @@ export async function getSharedContent({
 
   // If looking in the base folder,
   // also include orphaned shared content,
-  // i.e., shared content that is inside a non-shared parent.
+  // i.e., shared content that is inside a parent that isn't listed at the base folder.
   // That way, users can navigate to all of the owner's shared content
-  // when start at the base folder
+  // when start at the base folder.
+  // The parent condition must match `isDiscoverableSharedContent`, which lists only
+  // public (or shared-with-me) content, so an unlisted parent orphans its children.
   if (parentId === null) {
     const orphanedSharedContent = await prisma.content.findMany({
       where: {
         ownerId,
         parent: {
           AND: [
-            { visibility: { notIn: ["public", "unlisted"] } },
+            { visibility: { not: "public" } },
             {
               sharedWith: { none: { userId: loggedInUserId } },
             },

--- a/apps/api/src/query/content_list.ts
+++ b/apps/api/src/query/content_list.ts
@@ -412,22 +412,18 @@ export async function getSharedContent({
 
   // If looking in the base folder,
   // also include orphaned shared content,
-  // i.e., shared content that is inside a parent that isn't listed at the base folder.
+  // i.e., shared content whose parent is itself not listed at the base folder.
   // That way, users can navigate to all of the owner's shared content
   // when start at the base folder.
-  // The parent condition must match `isDiscoverableSharedContent`, which lists only
-  // public (or shared-with-me) content, so an unlisted parent orphans its children.
+  // The parent condition is the exact negation of `isDiscoverableSharedContent`,
+  // which is what determines whether the parent is listed here,
+  // so an unlisted parent (not listed itself) orphans its children.
   if (parentId === null) {
     const orphanedSharedContent = await prisma.content.findMany({
       where: {
         ownerId,
         parent: {
-          AND: [
-            { visibility: { not: "public" } },
-            {
-              sharedWith: { none: { userId: loggedInUserId } },
-            },
-          ],
+          NOT: isDiscoverableSharedContent(loggedInUserId),
         },
         // Note: don't use viewable filter, as we require it to be public/shared even if owned by loggedInUserId
         isDeletedOn: null,

--- a/apps/api/src/test/folder.test.ts
+++ b/apps/api/src/test/folder.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
-import { createTestUser } from "./utils";
+import { createTestUser, doc, fold, setupTestContent } from "./utils";
+import { updateVisibility } from "../access";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { getMyContent, getSharedContent } from "../query/content_list";
 import {
@@ -2157,4 +2158,51 @@ test("getSharedContent does not provide email", async () => {
   });
   expect(results.content.length).eqls(1);
   expect(results.content[0].owner).not.toHaveProperty("email");
+});
+
+test("getSharedContent hoists public content out of an unlisted folder", async () => {
+  const { userId: ownerId } = await createTestUser();
+  const { userId: viewerId } = await createTestUser();
+
+  const [unlistedFolderId, publicDocId, unlistedDocId] = await setupTestContent(
+    ownerId,
+    {
+      "unlisted folder": fold({
+        "public doc": doc(""),
+        "unlisted doc": doc(""),
+      }),
+    },
+  );
+
+  await updateVisibility({
+    contentId: unlistedFolderId,
+    loggedInUserId: ownerId,
+    visibility: "unlisted",
+  });
+  await setContentIsPublic({
+    contentId: publicDocId,
+    loggedInUserId: ownerId,
+    isPublic: true,
+  });
+
+  // The unlisted folder itself is not listed at the base folder,
+  // so its public child must be hoisted there instead.
+  const baseContent = await getSharedContent({
+    ownerId,
+    parentId: null,
+    loggedInUserId: viewerId,
+  });
+  expect(baseContent.content.map((c) => c.contentId)).eqls([publicDocId]);
+
+  // The unlisted folder is still browsable by direct link, showing both children.
+  const folderContent = await getSharedContent({
+    ownerId,
+    parentId: unlistedFolderId,
+    loggedInUserId: viewerId,
+  });
+  expect(folderContent.parent?.contentId).eqls(unlistedFolderId);
+  expect(folderContent.content.map((c) => c.contentId)).eqls([
+    publicDocId,
+    unlistedDocId,
+  ]);
 });


### PR DESCRIPTION
## Problem

An author's public activity can be invisible on their shared activities page while still appearing in Explore. This will occur if a public activity is inside an unlisted folder.

## Cause

`getSharedContent` builds the base listing from two queries that disagreed about `unlisted`:

- The main listing uses `isDiscoverableSharedContent` (`content_list.ts:28-38`): public **or** shared-with-me. An unlisted folder is therefore **not** listed.
- The orphan backfill, which exists precisely to surface public content trapped under a parent the viewer cannot see, required the parent to be `notIn: ["public", "unlisted"]` — i.e. it treated an unlisted parent as reachable and declined to hoist.

So the folder was hidden and its public child was not hoisted. Nothing was reachable.

Explore has no parent/depth constraint at all, which is correct for a flat search results page, hence the divergence.

## Fix

Align the orphan parent condition with `isDiscoverableSharedContent` by expressing it as
that predicate's exact negation, so the two cannot drift apart again:

```diff
-        parent: {
-          AND: [
-            { visibility: { notIn: ["public", "unlisted"] } },
-            { sharedWith: { none: { userId: loggedInUserId } } },
-          ],
-        },
+        parent: {
+          NOT: isDiscoverableSharedContent(loggedInUserId),
+        },
```

The behavioral change is that an unlisted parent now counts as "not listed", so its
public children are hoisted. The `sharedWith` half is unchanged in meaning.

## Why one level of parent is sufficient

`updateVisibility` enforces that a child cannot be less public than its parent (`access/visibility.ts:76-85`), so visibility is non-decreasing as you descend. Every public item is then reachable from the base folder:

- at root → listed directly;
- direct parent is public → that parent is itself public and reachable by induction, and browsing into it lists public children via `isOpenableSharedFolder`;
- direct parent is not public → hoisted by the orphan query.

No ancestor-chain walk is needed. The `sharedWith` half of the condition remains correct: a private/unlisted folder shared with the viewer is already listed at root, so its children should not be hoisted.

Browsing into an unlisted folder by direct link continues to work and to show unlisted children — that path uses `isOpenableSharedFolder` and is untouched.

## Testing

New test in `folder.test.ts` covers both halves: a public doc inside an unlisted folder is hoisted to the base listing, and the unlisted folder remains browsable by direct link showing both children.

Full API suite passes: 381 tests across 27 files.

## Follow-up

`copy_move.ts:652-653` still treats visibility as binary (`desiredParentIsPublic ? "public" : "private"`), so copying into an *unlisted* folder produces a `private` child — violating the invariant this fix relies on. Addressed in #3024, which is independent of this PR and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3bUTUym3xhuXLegDyTNZ2