### PR TITLE
fix: preserve visibility invariant when copying or moving content

### DIFF
--- a/apps/api/src/access/visibility.ts
+++ b/apps/api/src/access/visibility.ts
@@ -145,6 +145,10 @@ export async function updateVisibility({
  * a child may not be less public than its parent. Unlike {@link updateVisibility},
  * this never demotes, so moving a folder holding public content into an unlisted
  * one does not hide that content.
+ *
+ * Assignments are skipped, as they are always private. Ownership and the criteria
+ * for public sharing (see {@link getPublicShareViolations}) are not checked here:
+ * the content is following a parent that already satisfies them.
  */
 export async function raiseVisibility({
   contentId,
@@ -164,27 +168,20 @@ export async function raiseVisibility({
     (v) => visibilityOrder[v] < visibilityOrder[visibility],
   );
 
-  const filter = {
-    id: { in: [contentId, ...descendantIds] },
-    visibility: { in: lessPublic },
-    ...filterExcludeAssignments,
-  };
-
-  const updateTimestamp = prisma.content.updateMany({
-    where: filter,
-    data: { publiclySharedAt: visibility === "public" ? new Date() : null },
-  });
-
-  const updateContent = prisma.content.updateMany({
-    where: filter,
+  // Since the filter already selects only the rows whose visibility changes,
+  // visibility and the share timestamp can be updated in a single statement.
+  await prisma.content.updateMany({
+    where: {
+      id: { in: [contentId, ...descendantIds] },
+      visibility: { in: lessPublic },
+      ...filterExcludeAssignments,
+    },
     data: {
       visibility,
       isPublic: visibility === "public", // legacy flag, remove eventually
+      publiclySharedAt: visibility === "public" ? new Date() : null,
     },
   });
-
-  // Note: updateTimestamp first because it checks `visibility` status
-  await prisma.$transaction([updateTimestamp, updateContent]);
 }
 
 // __________________________________________________________________________

--- a/apps/api/src/access/visibility.ts
+++ b/apps/api/src/access/visibility.ts
@@ -137,6 +137,56 @@ export async function updateVisibility({
   return { visibility };
 }
 
+/**
+ * Raises `contentId` and its descendants to at least `visibility`, leaving any
+ * that are already more public untouched.
+ *
+ * Used when content lands inside a parent that is more public than it is, since
+ * a child may not be less public than its parent. Unlike {@link updateVisibility},
+ * this never demotes, so moving a folder holding public content into an unlisted
+ * one does not hide that content.
+ */
+export async function raiseVisibility({
+  contentId,
+  visibility,
+}: {
+  contentId: Uint8Array;
+  visibility: Visibility;
+}) {
+  if (visibility === "private") {
+    return;
+  }
+
+  const descendantIds = await getDescendantIds(contentId, {
+    excludeAssignments: true,
+  });
+  const lessPublic = (Object.keys(visibilityOrder) as Visibility[]).filter(
+    (v) => visibilityOrder[v] < visibilityOrder[visibility],
+  );
+
+  const filter = {
+    id: { in: [contentId, ...descendantIds] },
+    visibility: { in: lessPublic },
+    ...filterExcludeAssignments,
+  };
+
+  const updateTimestamp = prisma.content.updateMany({
+    where: filter,
+    data: { publiclySharedAt: visibility === "public" ? new Date() : null },
+  });
+
+  const updateContent = prisma.content.updateMany({
+    where: filter,
+    data: {
+      visibility,
+      isPublic: visibility === "public", // legacy flag, remove eventually
+    },
+  });
+
+  // Note: updateTimestamp first because it checks `visibility` status
+  await prisma.$transaction([updateTimestamp, updateContent]);
+}
+
 // __________________________________________________________________________
 //
 //

--- a/apps/api/src/query/copy_move.ts
+++ b/apps/api/src/query/copy_move.ts
@@ -74,7 +74,7 @@ export async function moveContent({
           isLibrary: true,
         },
       },
-      isPublic: true,
+      visibility: true,
       parent: {
         select: {
           isAssignmentRoot: true,
@@ -132,11 +132,9 @@ export async function moveContent({
 
     // If the parent is shared, then we'll need to share the resulting content, as well.
     if (parent.visibility !== "private") {
-      if (
-        parent.visibility === "public" &&
-        content.owner.isLibrary &&
-        !content.isPublic
-      ) {
+      // Moving into a shared parent raises the content's visibility, which for
+      // an unpublished library draft would share curated content implicitly.
+      if (content.owner.isLibrary && content.visibility !== "public") {
         throw new InvalidRequestError(
           "Cannot move draft from library to published folder/activity",
         );

--- a/apps/api/src/query/copy_move.ts
+++ b/apps/api/src/query/copy_move.ts
@@ -132,9 +132,13 @@ export async function moveContent({
 
     // If the parent is shared, then we'll need to share the resulting content, as well.
     if (parent.visibility !== "private") {
-      // Moving into a shared parent raises the content's visibility, which for
-      // an unpublished library draft would share curated content implicitly.
-      if (content.owner.isLibrary && content.visibility !== "public") {
+      // Moving into a public parent would publish an unpublished library draft,
+      // bypassing curation. Moving into an unlisted parent is not publishing.
+      if (
+        parent.visibility === "public" &&
+        content.owner.isLibrary &&
+        content.visibility !== "public"
+      ) {
         throw new InvalidRequestError(
           "Cannot move draft from library to published folder/activity",
         );

--- a/apps/api/src/query/copy_move.ts
+++ b/apps/api/src/query/copy_move.ts
@@ -1,6 +1,7 @@
 import { ContentType, Prisma } from "@prisma/client";
 import { prisma } from "../model";
-import { LicenseCode, UserInfo } from "../types";
+import { LicenseCode, UserInfo, Visibility } from "../types";
+import { raiseVisibility } from "../access";
 import {
   filterEditableContent,
   filterExcludeAssignments,
@@ -14,7 +15,7 @@ import {
   getNextSortIndexForParent,
   ShiftIndicesCallbackFunction,
 } from "../utils/sort";
-import { modifyContentSharedWith, setContentIsPublic } from "./share";
+import { modifyContentSharedWith } from "./share";
 import {
   createContentRevision,
   createContent,
@@ -88,7 +89,7 @@ export async function moveContent({
     );
   }
 
-  let desiredParentIsPublic = false;
+  let desiredParentVisibility: Visibility = "private";
   let desiredParentLicenseCode: LicenseCode = "CCDUAL";
   let desiredParentShares: Uint8Array[] = [];
 
@@ -111,7 +112,7 @@ export async function moveContent({
       },
       select: {
         type: true,
-        isPublic: true,
+        visibility: true,
         licenseCode: true,
         courseRootId: true,
         sharedWith: { select: { userId: true } },
@@ -130,13 +131,17 @@ export async function moveContent({
     }
 
     // If the parent is shared, then we'll need to share the resulting content, as well.
-    if (parent.isPublic) {
-      if (content.owner.isLibrary && !content.isPublic) {
+    if (parent.visibility !== "private") {
+      if (
+        parent.visibility === "public" &&
+        content.owner.isLibrary &&
+        !content.isPublic
+      ) {
         throw new InvalidRequestError(
           "Cannot move draft from library to published folder/activity",
         );
       }
-      desiredParentIsPublic = true;
+      desiredParentVisibility = parent.visibility;
       if (parent.licenseCode) {
         desiredParentLicenseCode = parent.licenseCode as LicenseCode;
       }
@@ -326,13 +331,13 @@ export async function moveContent({
     });
   }
 
-  if (desiredParentIsPublic) {
-    await setContentIsPublic({
-      contentId: content.id,
-      loggedInUserId,
-      isPublic: true,
-    });
-  }
+  // A child may not be less public than its parent, so raise the moved content
+  // to the parent's visibility. Never demote: content that is already more
+  // public than its new parent keeps its visibility.
+  await raiseVisibility({
+    contentId: content.id,
+    visibility: desiredParentVisibility,
+  });
 
   if (desiredParentShares.length > 0) {
     await modifyContentSharedWith({
@@ -397,7 +402,7 @@ export async function copyContent({
     throw new InvalidRequestError("Content not found or not visible");
   }
 
-  let desiredParentIsPublic = false;
+  let desiredParentVisibility: Visibility = "private";
   let desiredParentLicenseCode: LicenseCode = "CCDUAL";
   let desiredParentShares: Uint8Array[] = [];
   let desiredParentType: ContentType = "folder";
@@ -413,7 +418,7 @@ export async function copyContent({
         type: { not: "singleDoc" },
       },
       select: {
-        isPublic: true,
+        visibility: true,
         type: true,
         licenseCode: true,
         sharedWith: { select: { userId: true } },
@@ -431,8 +436,8 @@ export async function copyContent({
     desiredParentType = parent.type;
 
     // If the parent folder is public/shared, then we'll need to share the resulting content, as well
-    if (parent.isPublic) {
-      desiredParentIsPublic = true;
+    if (parent.visibility !== "private") {
+      desiredParentVisibility = parent.visibility;
       if (parent.licenseCode) {
         desiredParentLicenseCode = parent.licenseCode as LicenseCode;
       }
@@ -507,7 +512,7 @@ export async function copyContent({
         parentId,
         prependCopy,
         isEditor,
-        desiredParentIsPublic,
+        desiredParentVisibility,
         desiredParentLicenseCode,
         desiredParentShares,
         desiredParentType,
@@ -529,7 +534,7 @@ async function copySingleContent({
   parentId,
   prependCopy,
   isEditor,
-  desiredParentIsPublic,
+  desiredParentVisibility,
   desiredParentLicenseCode,
   desiredParentShares,
   desiredParentType,
@@ -540,7 +545,7 @@ async function copySingleContent({
   parentId: Uint8Array | null;
   prependCopy: boolean;
   isEditor: boolean;
-  desiredParentIsPublic: boolean;
+  desiredParentVisibility: Visibility;
   desiredParentLicenseCode: LicenseCode;
   desiredParentShares: Uint8Array[];
   desiredParentType: ContentType;
@@ -616,7 +621,7 @@ async function copySingleContent({
         parentId,
         prependCopy: false,
         isEditor,
-        desiredParentIsPublic,
+        desiredParentVisibility,
         desiredParentLicenseCode,
         desiredParentShares,
         desiredParentType,
@@ -649,8 +654,10 @@ async function copySingleContent({
         ownerId: loggedInUserId,
         parentId: parentId,
         sortIndex,
-        isPublic: desiredParentIsPublic,
-        visibility: desiredParentIsPublic ? "public" : "private",
+        // A child may not be less public than its parent, so the copy inherits
+        // the parent's visibility.
+        isPublic: desiredParentVisibility === "public",
+        visibility: desiredParentVisibility,
         licenseCode,
         courseRootId: desiredCourseId,
         classCode,
@@ -712,7 +719,7 @@ async function copySingleContent({
         parentId: newContent.id,
         prependCopy: false,
         isEditor,
-        desiredParentIsPublic,
+        desiredParentVisibility,
         desiredParentLicenseCode,
         desiredParentShares,
         desiredParentType,

--- a/apps/api/src/test/copy_move.test.ts
+++ b/apps/api/src/test/copy_move.test.ts
@@ -19,6 +19,7 @@ import {
   moveContent,
 } from "../query/copy_move";
 import { setContentIsPublic } from "../query/share";
+import { updateVisibility } from "../access";
 import { getMyContent } from "../query/content_list";
 import { getContent } from "../query/activity_edit_view";
 import { isEqualUUID } from "../utils/uuid";
@@ -1630,5 +1631,105 @@ describe("moveContent() with courses", () => {
       loggedInUserId: ownerId,
     });
     expect(description.parent?.contentId).eqls(courseFolder2);
+  });
+});
+
+describe("visibility invariant: a child may not be less public than its parent", () => {
+  async function visibilityOf(
+    contentId: Uint8Array,
+    loggedInUserId: Uint8Array,
+  ) {
+    const content = await getContent({ contentId, loggedInUserId });
+    return content.visibility;
+  }
+
+  test("copying into an unlisted folder makes the copy unlisted, not private", async () => {
+    const { userId: ownerId } = await createTestUser();
+
+    const [unlistedFolderId, docId] = await setupTestContent(ownerId, {
+      "unlisted folder": fold({}),
+      "a doc": doc(""),
+    });
+
+    await updateVisibility({
+      contentId: unlistedFolderId,
+      loggedInUserId: ownerId,
+      visibility: "unlisted",
+    });
+
+    const { newContentIds } = await copyContent({
+      contentIds: [docId],
+      parentId: unlistedFolderId,
+      loggedInUserId: ownerId,
+    });
+
+    expect(await visibilityOf(newContentIds[0], ownerId)).eqls("unlisted");
+  });
+
+  test("moving private content into an unlisted folder makes it unlisted", async () => {
+    const { userId: ownerId } = await createTestUser();
+
+    const [unlistedFolderId, docId] = await setupTestContent(ownerId, {
+      "unlisted folder": fold({}),
+      "a doc": doc(""),
+    });
+
+    await updateVisibility({
+      contentId: unlistedFolderId,
+      loggedInUserId: ownerId,
+      visibility: "unlisted",
+    });
+
+    await moveContent({
+      contentId: docId,
+      changeParentIdTo: unlistedFolderId,
+      desiredPosition: 0,
+      loggedInUserId: ownerId,
+    });
+
+    expect(await visibilityOf(docId, ownerId)).eqls("unlisted");
+  });
+
+  test("moving into an unlisted folder does not demote public content", async () => {
+    const { userId: ownerId } = await createTestUser();
+
+    const [unlistedFolderId, folderId, publicDocId, privateDocId] =
+      await setupTestContent(ownerId, {
+        "unlisted folder": fold({}),
+        "a folder": fold({ "public doc": doc(""), "private doc": doc("") }),
+      });
+
+    await updateVisibility({
+      contentId: unlistedFolderId,
+      loggedInUserId: ownerId,
+      visibility: "unlisted",
+    });
+    await setContentIsPublic({
+      contentId: publicDocId,
+      loggedInUserId: ownerId,
+      isPublic: true,
+    });
+
+    await moveContent({
+      contentId: folderId,
+      changeParentIdTo: unlistedFolderId,
+      desiredPosition: 0,
+      loggedInUserId: ownerId,
+    });
+
+    // The private doc is raised to the parent's level; the public doc keeps its visibility.
+    const inUnlistedFolder = await getMyContent({
+      ownerId,
+      loggedInUserId: ownerId,
+      parentId: unlistedFolderId,
+    });
+    if (inUnlistedFolder.notMe) {
+      throw Error("shouldn't happen");
+    }
+    expect(inUnlistedFolder.content).toMatchObject([
+      { contentId: folderId, visibility: "unlisted" },
+    ]);
+    expect(await visibilityOf(privateDocId, ownerId)).eqls("unlisted");
+    expect(await visibilityOf(publicDocId, ownerId)).eqls("public");
   });
 });


### PR DESCRIPTION
Independent of #3023 (both branch from `main`); the two can land in either order.

## Problem

`updateVisibility` enforces that **a child may not be less public than its parent** (`access/visibility.ts:76-85`). `copy_move.ts` predates `unlisted` and still reasons in terms of the binary `isPublic` flag, so it treats an unlisted parent as private and breaks that invariant:

- **Copy** (`copy_move.ts:656-657`): `visibility: desiredParentIsPublic ? "public" : "private"` — copying into an unlisted folder produced a **private** child.
- **Move** (`copy_move.ts:329-335`): only promoted when `parent.isPublic`, so moving content into an unlisted folder left it **private**.

Practical symptom: someone holding an unlisted folder's link sees its other children but not the newly copied or moved one.

This also undermines the reachability argument that #3023 relies on, which assumes the invariant holds in the data.

## Fix

Read the parent's actual `visibility` instead of `isPublic`:

- A **copy** inherits the parent's visibility directly. For public and private parents this is exactly the previous behavior; unlisted parents now yield unlisted copies rather than private ones.
- **Moved** content is raised to the parent's visibility via a new `raiseVisibility` helper.

### Why a new helper rather than `updateVisibility`

`updateVisibility` cascades one visibility to every descendant, so it can *demote*. Using it here would mean that moving a folder containing a public doc into an unlisted folder silently hides that doc.

`raiseVisibility` promotes only content strictly below the target level, leaving anything already more public untouched. It replaces the previous `setContentIsPublic` call on the move path; for a public parent the outcome is identical, since nothing can be more public than public.

The library guard ("Cannot move draft from library to published folder/activity") keeps its existing scope: it fires only for a **public** parent. Moving a draft into an unlisted folder is not publishing it. Its content check now reads `visibility` rather than the legacy `isPublic` flag, which is equivalent since the two are kept in sync.

## Testing

Three new tests in `copy_move.test.ts`:

- copying into an unlisted folder makes the copy unlisted, not private;
- moving private content into an unlisted folder makes it unlisted;
- moving a folder into an unlisted folder raises its private child to unlisted while leaving its public child public.

`raiseVisibility` skips assignments and does not re-check ownership or the public-share
criteria, matching the `setContentIsPublic` call it replaces: the content is following a
parent that already satisfies them.

Full API suite passes: 383 tests across 27 files.

## Not addressed here

Existing rows in production may already violate the invariant, since this bug has been live. A data audit is worth doing separately. The deprecated `setContentIsPublic` (`query/share.ts:20`) is another binary-visibility path still in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3bUTUym3xhuXLegDyTNZ2
