### PR TITLE
Add description documents to problem sets

### DIFF
--- a/MANUAL_MIGRATION_PLAN.md
+++ b/MANUAL_MIGRATION_PLAN.md
@@ -1,0 +1,245 @@
+# Manual migration plan — `20260814120000_problem_set_description_doc`
+
+Runbook for applying the `content.isDescription` migration to **prod** by hand,
+ahead of deploying the image from PR #3026.
+
+## Why this is not a normal deploy
+
+`content` carries two FULLTEXT indexes (`content_name_idx`, `content_source_idx`).
+InnoDB cannot use `ALGORITHM=INSTANT` or `INPLACE` for `ADD COLUMN` on such a
+table, so it falls all the way back to `ALGORITHM=COPY` — a full table rebuild.
+MySQL says so itself:
+
+```
+mysql> ALTER TABLE content ADD COLUMN _x BOOLEAN NOT NULL DEFAULT false, ALGORITHM=INSTANT;
+ERROR 1846 (0A000): ALGORITHM=INSTANT is not supported. Reason: InnoDB presently
+supports one FULLTEXT index creation at a time. Try ALGORITHM=COPY/INPLACE.
+```
+
+Measured on dev3 (403 MB): **7 min 3 s**. The backend deploy allows **5 minutes**
+(`timeout-minutes` defaults to `5` in `.github/actions/update-cluster-with-rollback`,
+not overridden by `reusable-deploy-backend.yml`), and `entrypoint.sh` runs
+`prisma migrate deploy` _before_ the server listens — so the task never passes a
+health check while the rebuild runs, and the deploy kills it partway.
+
+MySQL has no transactional DDL: the column commits but Prisma never writes
+`finished_at`. Every later deploy then fails with `P3009` — **including a
+rollback to `main`** — until someone runs `prisma migrate resolve` by hand. This
+happened on dev3 on 2026-08-15 and left it undeployable until cleared manually.
+
+Tracked in #3027. Until that is addressed, migrations touching `content` must be
+applied out-of-band.
+
+## Expected cost on prod
+
+|                 | dev3      | prod                    |
+| --------------- | --------- | ----------------------- |
+| `content` data  | 383 MB    | 459 MB                  |
+| `content` index | 20 MB     | 24 MB                   |
+| Rebuild time    | 7 min 3 s | **~8–9 min (estimate)** |
+
+Scale from dev3 with care — prod's MySQL container may not perform identically,
+and the FULLTEXT rebuild may not scale linearly. **Budget 15–20 minutes and
+decide the abort point before starting.**
+
+`ALGORITHM=COPY` permits reads but **blocks writes** for the whole rebuild. The
+site is read-only during the window, not down.
+
+## 1. Pre-flight
+
+Take a database backup. Open a maintenance window.
+
+Confirm prod is at exactly 20 applied migrations with nothing broken — otherwise
+the deploy will also run whatever else is outstanding:
+
+```sql
+SELECT COUNT(*) FROM _prisma_migrations
+WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL;          -- expect 20
+
+SELECT migration_name, started_at FROM _prisma_migrations
+WHERE finished_at IS NULL OR rolled_back_at IS NOT NULL;           -- expect empty
+```
+
+_Verified 2026-08-17: 20 applied, none broken._
+
+### Separate concern — repeated documents in live assignments
+
+PR #3026 also makes `repeatInProblemSet` take effect for students for the first
+time, so a problem set that was **assigned before this deploy** with a repeated
+document gains items on the next student load, and its gradebook columns shift
+with them.
+
+Prod has **15** documents with `repeatInProblemSet > 1`. Identify which sit
+inside an assignment with existing student work:
+
+```sql
+SELECT c.name  AS document,
+       p.name  AS problem_set,
+       p.isAssignmentRoot,
+       (SELECT COUNT(*) FROM contentState  cs WHERE cs.contentId = p.id) AS attempts,
+       (SELECT COUNT(*) FROM contentItemState cis WHERE cis.contentId = p.id) AS item_rows
+FROM content c
+JOIN content p ON c.parentId = p.id
+WHERE c.repeatInProblemSet > 1
+  AND c.isDeletedOn IS NULL;
+```
+
+Rows with `isAssignmentRoot = 1` and a non-zero `attempts` are the ones at risk.
+
+**Reviewed 2026-08-17 — no action needed.** Of the 15, nine have a live parent;
+three of those sit in an assigned problem set:
+
+| problem set                 | attempts | item rows |
+| --------------------------- | -------- | --------- |
+| Untitled Problem Set        | 2        | 9         |
+| Demo Problem Set for Debbie | 1        | 3         |
+| Demo Problem Set for Debbie | 0        | 0         |
+
+All appear to be experimental or demo content rather than live coursework, and
+the affected student work is negligible. Decision: **proceed without resetting**.
+
+The remaining six are excluded by the query above because they are soft-deleted
+(`isDeletedOn` set), so they compile to nothing — verified 2026-08-17. To
+re-check later:
+
+```sql
+SELECT c.name AS document,
+       c.repeatInProblemSet,
+       (c.isDeletedOn IS NOT NULL) AS doc_deleted,
+       p.name AS problem_set,
+       p.type AS parent_type,
+       p.isAssignmentRoot,
+       c.lastEdited
+FROM content c
+LEFT JOIN content p ON c.parentId = p.id
+WHERE c.repeatInProblemSet > 1;
+```
+
+Should this ever need reverting for a real course, the repeat has never actually
+reached students, so resetting loses nothing:
+
+```sql
+-- only after reviewing the query above
+UPDATE content SET repeatInProblemSet = 1 WHERE id = <id>;
+```
+
+Re-check this before deploying if significant time has passed — an instructor
+could assign a problem set with a repeated document in the meantime.
+
+## 2. Apply the migration
+
+Exactly the SQL from
+`apps/api/prisma/migrations/20260814120000_problem_set_description_doc/migration.sql`:
+
+```sql
+ALTER TABLE `content` ADD COLUMN `isDescription` BOOLEAN NOT NULL DEFAULT false;
+```
+
+**Run it somewhere that survives a dropped connection** — `screen`, `tmux`, or
+`nohup mysql -e "…" &`. An ECS exec session dying at minute 7 kills the `ALTER`.
+That is recoverable (COPY discards the temp table and leaves the original
+intact) but means starting over.
+
+To watch progress from a second session:
+
+```sql
+SHOW PROCESSLIST;   -- the ALTER shows State = "copy to tmp table"
+```
+
+## 3. Record it in Prisma's bookkeeping
+
+Prod has no row for this migration yet, so insert one. The checksum is the
+SHA-256 of the migration file, and has been verified against the row Prisma
+itself wrote on dev3:
+
+```sql
+INSERT INTO _prisma_migrations
+  (id, checksum, migration_name, started_at, finished_at, applied_steps_count)
+VALUES
+  (UUID(),
+   'cffbbc8e54852ec48adcffca534a0c8eeb0c0d10ae13101f8b84274cd1985a2b',
+   '20260814120000_problem_set_description_doc',
+   NOW(3), NOW(3), 1);
+```
+
+`logs` and `rolled_back_at` are nullable and correctly left unset.
+
+> The checksum must be exact. Prisma verifies applied migrations against it, and
+> a mismatch fails the next deploy with "migration has been modified". If
+> `migration.sql` is ever edited, this value changes.
+
+`prisma migrate resolve --applied` would normally do this, but it requires the
+migration directory to exist locally, and the currently-running prod image
+predates it — that path fails with `P3017`.
+
+## 4. Verify before deploying
+
+```sql
+SHOW COLUMNS FROM content LIKE 'isDescription';
+-- expect: tinyint(1), Null = NO, Default = 0
+
+SELECT COUNT(*) FROM _prisma_migrations
+WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL;          -- now 21
+```
+
+Both must pass before step 5.
+
+## 5. Deploy
+
+Deploy the image normally. `prisma migrate deploy` finds 21 of 21 applied and
+goes straight to `npm run start`; the task should reach steady state in about a
+minute, as healthy rollouts do.
+
+If it instead sits unhealthy for 5 minutes, step 3 did not take. **Do not simply
+retry** — a retry cannot fix a bookkeeping problem. Read the task's stdout
+first:
+
+```bash
+aws logs tail prod --region us-east-2 --since 15m \
+  --log-stream-name-prefix doenet/doenet/ --format short
+```
+
+## Backing out
+
+Reverting the schema means another full rebuild of the same length and another
+write freeze:
+
+```sql
+ALTER TABLE content DROP COLUMN isDescription;
+DELETE FROM _prisma_migrations
+WHERE migration_name = '20260814120000_problem_set_description_doc';
+```
+
+Usually the better option is to leave the column and roll back only the
+application image. The column is additive, and the old code neither reads nor
+writes it.
+
+## Alternative: let Prisma do its own bookkeeping
+
+Avoids the manual `INSERT` entirely. The deploy pushes to a **mutable** image tag
+and only runs `update-service --force-new-deployment` — it never registers a new
+task definition — so a one-off task launched after the push picks up the new
+image:
+
+1. Build and push the image to the prod tag **without** updating the service
+   (the workflow does both in one job, so this means running the docker
+   build/push steps by hand).
+2. `aws ecs run-task --cluster prod --task-definition <current def>` — no load
+   balancer and no health-check clock, so the migration can take as long as it
+   needs, and Prisma writes its own row.
+3. Watch the task's logs; stop it once the migration completes.
+4. Deploy normally.
+
+More faithful to what Prisma expects, at the cost of a manual image push.
+
+## Provenance
+
+Everything above was verified against **dev3** — the rebuild timing, the
+`ALGORITHM=INSTANT` error, the checksum, and the `_prisma_migrations` schema —
+and against the deploy tooling in `.github/`. **None of it has been executed
+against prod.** Step 4 is the gate.
+
+Prod facts confirmed 2026-08-17: cluster `prod`, service `doenet-FARGATE`,
+`HealthCheckGracePeriod` 600s (the deploy script still gives up at 300s),
+`content` at 459 MB + 24 MB index, 20 migrations applied, 15 documents with
+`repeatInProblemSet > 1`.

--- a/apps/api/prisma/migrations/20260814120000_problem_set_description_doc/migration.sql
+++ b/apps/api/prisma/migrations/20260814120000_problem_set_description_doc/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `content` ADD COLUMN `isDescription` BOOLEAN NOT NULL DEFAULT false;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -50,6 +50,9 @@ model content {
   accessibilityCheck     AuditState               @default(unchecked)
   // Specific to documents inside problem sets
   repeatInProblemSet     Int                      @default(1)
+  // A description is rendered like any other document but is not one of the
+  // scored items: no problem number, no credit, no item state of its own.
+  isDescription          Boolean                  @default(false)
   // 
   // ====== Problem Sets =========
   shuffle                Boolean                  @default(false)

--- a/apps/api/src/query/activity.ts
+++ b/apps/api/src/query/activity.ts
@@ -471,7 +471,7 @@ export async function updateContent({
       throw new InvalidRequestError("Cannot change assigned content");
     }
   }
-  if (repeatInProblemSet || isDescription !== undefined) {
+  if (repeatInProblemSet !== undefined || isDescription !== undefined) {
     // Make sure this content is a document and the parent is a problem set
     const check = await prisma.content.findUniqueOrThrow({
       where: {
@@ -493,7 +493,7 @@ export async function updateContent({
       );
     }
 
-    if (repeatInProblemSet) {
+    if (repeatInProblemSet !== undefined) {
       // Clamp the repeats between 1 and the number of variants this doc has
       // (doesn't make sense to repeat exact problem twice)
       repeatInProblemSet = Math.max(repeatInProblemSet, 1);

--- a/apps/api/src/query/activity.ts
+++ b/apps/api/src/query/activity.ts
@@ -374,7 +374,8 @@ export async function restoreDeletedContent({
  * Update the content with `contentId`, changing any of the parameters that are given:
  * `name`, `source`, `doenetmlVersionId`, `numVariants`,
  * `shuffle`, `numToSelect`, `selectByVariant`,
- * `paginate`, `activityLevelAttempts`, `itemLevelAttempts`, and/or `repeatInProblemSet`.
+ * `paginate`, `activityLevelAttempts`, `itemLevelAttempts`, `repeatInProblemSet`,
+ * and/or `isDescription`.
  *
  * For the change to succeed, either
  * - the content must be owned by `loggedInUserId`, or
@@ -382,8 +383,8 @@ export async function restoreDeletedContent({
  * In addition, if the content is assigned, then the change will succeed
  * only if just modifying `name`, and/or `paginate`.
  *
- * If you are trying to modify `repeatInProblemSet`, the content must be a document and
- * the content's parent must be a problem set.
+ * If you are trying to modify `repeatInProblemSet` or `isDescription`, the content
+ * must be a document and the content's parent must be a problem set.
  */
 export async function updateContent({
   contentId,
@@ -396,6 +397,7 @@ export async function updateContent({
   selectByVariant,
   paginate,
   repeatInProblemSet,
+  isDescription,
   loggedInUserId,
 }: {
   contentId: Uint8Array;
@@ -408,6 +410,7 @@ export async function updateContent({
   selectByVariant?: boolean;
   paginate?: boolean;
   repeatInProblemSet?: number;
+  isDescription?: boolean;
   loggedInUserId: Uint8Array;
 }) {
   if (
@@ -421,6 +424,7 @@ export async function updateContent({
       selectByVariant,
       paginate,
       repeatInProblemSet,
+      isDescription,
     ].every((x) => x === undefined)
   ) {
     // if no information passed in, don't update anything, including `lastEdited`.
@@ -459,12 +463,15 @@ export async function updateContent({
         selectByVariant,
         // paginate,
         repeatInProblemSet,
+        // Changing `isDescription` renumbers the items, which would no longer
+        // line up with the item numbers of existing attempts.
+        isDescription,
       ].some((x) => x !== undefined)
     ) {
       throw new InvalidRequestError("Cannot change assigned content");
     }
   }
-  if (repeatInProblemSet) {
+  if (repeatInProblemSet || isDescription !== undefined) {
     // Make sure this content is a document and the parent is a problem set
     const check = await prisma.content.findUniqueOrThrow({
       where: {
@@ -482,17 +489,19 @@ export async function updateContent({
     });
     if (check.type !== "singleDoc" || check.parent?.type !== "sequence") {
       throw new InvalidRequestError(
-        "Cannot modify `repeatInProblemSet` when content is not a document or parent is not a problem set.",
+        "Cannot modify `repeatInProblemSet` or `isDescription` when content is not a document or parent is not a problem set.",
       );
     }
 
-    // Clamp the repeats between 1 and the number of variants this doc has
-    // (doesn't make sense to repeat exact problem twice)
-    repeatInProblemSet = Math.max(repeatInProblemSet, 1);
-    repeatInProblemSet = Math.min(
-      repeatInProblemSet,
-      numVariants ?? check.numVariants,
-    );
+    if (repeatInProblemSet) {
+      // Clamp the repeats between 1 and the number of variants this doc has
+      // (doesn't make sense to repeat exact problem twice)
+      repeatInProblemSet = Math.max(repeatInProblemSet, 1);
+      repeatInProblemSet = Math.min(
+        repeatInProblemSet,
+        numVariants ?? check.numVariants,
+      );
+    }
   }
 
   await prisma.content.update({
@@ -511,6 +520,7 @@ export async function updateContent({
       selectByVariant,
       paginate,
       repeatInProblemSet,
+      isDescription,
       lastEdited: DateTime.now().toJSDate(),
     },
   });

--- a/apps/api/src/query/activity_edit_view.ts
+++ b/apps/api/src/query/activity_edit_view.ts
@@ -84,7 +84,6 @@ export async function getContent({
   includeClassifications = false,
   includeShareDetails = false,
   includeOwnerDetails = false,
-  includeRepeatInProblemSet = false,
   isEditor = false,
   skipPermissionCheck = false,
 }: {
@@ -94,7 +93,6 @@ export async function getContent({
   includeClassifications?: boolean;
   includeShareDetails?: boolean;
   includeOwnerDetails?: boolean;
-  includeRepeatInProblemSet?: boolean;
   isEditor?: boolean;
   skipPermissionCheck?: boolean;
 }) {
@@ -149,7 +147,6 @@ export async function getContent({
     includeClassifications,
     includeShareDetails,
     includeOwnerDetails,
-    includeRepeatInProblemSet,
   });
 
   const preliminaryList = await prisma.content.findMany({

--- a/apps/api/src/query/assign.ts
+++ b/apps/api/src/query/assign.ts
@@ -14,7 +14,11 @@ import { getRandomValues } from "crypto";
 import { AssignmentMode, ContentType, Prisma } from "@prisma/client";
 import { Content, ItemScores, ScoreData, UserInfo } from "../types";
 import { fromUUID, isEqualUUID } from "../utils/uuid";
-import { processContent, returnContentSelect } from "../utils/contentStructure";
+import {
+  processContent,
+  repeatCountInProblemSet,
+  returnContentSelect,
+} from "../utils/contentStructure";
 import { InvalidRequestError } from "../utils/error";
 import { getContent } from "./activity_edit_view";
 import {
@@ -871,6 +875,7 @@ export async function getAssignmentResponseStudent({
           numToSelect: true,
           repeatInProblemSet: true,
           isDescription: true,
+          numVariants: true,
         },
       },
     },
@@ -1450,6 +1455,7 @@ function getItemNames(
           numToSelect: number;
           repeatInProblemSet?: number;
           isDescription?: boolean;
+          numVariants?: number;
         }[];
       },
 ) {
@@ -1464,7 +1470,7 @@ function getItemNames(
     if (child.type === "singleDoc") {
       return child.isDescription
         ? []
-        : repeatedItemNames(child.name, child.repeatInProblemSet ?? 1);
+        : repeatedItemNames(child.name, repeatCountInProblemSet(child));
     }
     if (child.type === "select") {
       return repeatedItemNames(child.name, child.numToSelect);

--- a/apps/api/src/query/assign.ts
+++ b/apps/api/src/query/assign.ts
@@ -13,12 +13,9 @@ import {
 import { getRandomValues } from "crypto";
 import { AssignmentMode, ContentType, Prisma } from "@prisma/client";
 import { Content, ItemScores, ScoreData, UserInfo } from "../types";
+import { repeatCountInProblemSet } from "@doenet-tools/shared";
 import { fromUUID, isEqualUUID } from "../utils/uuid";
-import {
-  processContent,
-  repeatCountInProblemSet,
-  returnContentSelect,
-} from "../utils/contentStructure";
+import { processContent, returnContentSelect } from "../utils/contentStructure";
 import { InvalidRequestError } from "../utils/error";
 import { getContent } from "./activity_edit_view";
 import {

--- a/apps/api/src/query/assign.ts
+++ b/apps/api/src/query/assign.ts
@@ -865,7 +865,12 @@ export async function getAssignmentResponseStudent({
       children: {
         where: { isDeletedOn: null },
         orderBy: { sortIndex: "asc" },
-        select: { name: true, type: true, numToSelect: true },
+        select: {
+          name: true,
+          type: true,
+          numToSelect: true,
+          isDescription: true,
+        },
       },
     },
   });
@@ -1411,7 +1416,12 @@ async function getAllAttemptScores({
   }
 }
 
-/** Get a list of the names of the documents/selects in `content`, in original order. */
+/**
+ * Get a list of the names of the documents/selects in `content`, in original order.
+ *
+ * Descriptions are skipped: they are not scored items, so they hold no column
+ * in the gradebook and no `itemNumber` in the stored item state.
+ */
 function getItemNames(
   content:
     | Content
@@ -1423,6 +1433,7 @@ function getItemNames(
           name: string;
           type: ContentType;
           numToSelect: number;
+          isDescription?: boolean;
         }[];
       },
 ) {
@@ -1439,6 +1450,9 @@ function getItemNames(
   } else if (content.type === "sequence") {
     for (const child of content.children) {
       if (child.type === "singleDoc") {
+        if (child.isDescription) {
+          continue;
+        }
         itemNames.push(child.name);
       } else if (child.type === "select") {
         if (child.numToSelect === 1) {

--- a/apps/api/src/query/assign.ts
+++ b/apps/api/src/query/assign.ts
@@ -869,6 +869,7 @@ export async function getAssignmentResponseStudent({
           name: true,
           type: true,
           numToSelect: true,
+          repeatInProblemSet: true,
           isDescription: true,
         },
       },
@@ -1417,10 +1418,24 @@ async function getAllAttemptScores({
 }
 
 /**
+ * Names for the `count` items that `name` contributes to an activity,
+ * disambiguated by index unless there is just the one.
+ */
+function repeatedItemNames(name: string, count: number) {
+  if (count <= 1) {
+    return [name];
+  }
+  return Array.from({ length: count }, (_, i) => `${name} (${i + 1})`);
+}
+
+/**
  * Get a list of the names of the documents/selects in `content`, in original order.
  *
- * Descriptions are skipped: they are not scored items, so they hold no column
- * in the gradebook and no `itemNumber` in the stored item state.
+ * The result must line up one-to-one with the items of the compiled activity
+ * (see `compileActivityFromContent`), since the item names label the columns of
+ * the gradebook indexed by `itemNumber`. So a question bank contributes one name
+ * per selected item, a repeated document one name per copy, and a description
+ * none at all — a description is not a scored item.
  */
 function getItemNames(
   content:
@@ -1433,40 +1448,29 @@ function getItemNames(
           name: string;
           type: ContentType;
           numToSelect: number;
+          repeatInProblemSet?: number;
           isDescription?: boolean;
         }[];
       },
 ) {
-  const itemNames: string[] = [];
-
   if (content.type === "select") {
-    if (content.numToSelect === 1) {
-      itemNames.push(content.name);
-    } else {
-      for (let i = 1; i <= content.numToSelect; i++) {
-        itemNames.push(`${content.name} (${i})`);
-      }
-    }
-  } else if (content.type === "sequence") {
-    for (const child of content.children) {
-      if (child.type === "singleDoc") {
-        if (child.isDescription) {
-          continue;
-        }
-        itemNames.push(child.name);
-      } else if (child.type === "select") {
-        if (child.numToSelect === 1) {
-          itemNames.push(child.name);
-        } else {
-          for (let i = 1; i <= child.numToSelect; i++) {
-            itemNames.push(`${child.name} (${i})`);
-          }
-        }
-      }
-    }
+    return repeatedItemNames(content.name, content.numToSelect);
+  }
+  if (content.type !== "sequence") {
+    return [];
   }
 
-  return itemNames;
+  return content.children.flatMap((child) => {
+    if (child.type === "singleDoc") {
+      return child.isDescription
+        ? []
+        : repeatedItemNames(child.name, child.repeatInProblemSet ?? 1);
+    }
+    if (child.type === "select") {
+      return repeatedItemNames(child.name, child.numToSelect);
+    }
+    return [];
+  });
 }
 
 /**

--- a/apps/api/src/query/editor.ts
+++ b/apps/api/src/query/editor.ts
@@ -305,7 +305,6 @@ export async function getCompoundEditorView({
     isEditor,
     skipPermissionCheck: true,
     includeAssignInfo: true,
-    includeRepeatInProblemSet: true,
   });
 
   return {
@@ -350,7 +349,6 @@ export async function getCompoundEditorEdit({
     loggedInUserId,
     isEditor,
     skipPermissionCheck: true,
-    includeRepeatInProblemSet: true,
   });
 
   return { content };

--- a/apps/api/src/schemas/contentSchema.ts
+++ b/apps/api/src/schemas/contentSchema.ts
@@ -32,6 +32,7 @@ export const updateContentSettingsSchema = z.object({
   activityLevelAttempts: z.boolean().optional(),
   itemLevelAttempts: z.boolean().optional(),
   repeatInProblemSet: z.number().optional(),
+  isDescription: z.boolean().optional(),
 });
 
 export const updateCategoriesSchema = z.object({

--- a/apps/api/src/test/activity.test.ts
+++ b/apps/api/src/test/activity.test.ts
@@ -3,7 +3,14 @@ import { describe, expect, test, vi } from "vitest";
 import { DateTime } from "luxon";
 
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
-import { createTestUser, doc, fold, pset, setupTestContent } from "./utils";
+import {
+  createTestUser,
+  doc,
+  fold,
+  pset,
+  qbank,
+  setupTestContent,
+} from "./utils";
 import {
   createContent,
   deleteContent,
@@ -28,6 +35,7 @@ import { modifyContentSharedWith, setContentIsPublic } from "../query/share";
 import {
   closeAssignment,
   createAssignment,
+  getAssignmentResponseOverview,
   updateAssignmentClosedOn,
 } from "../query/assign";
 import { createNewAttempt, saveScoreAndState } from "../query/scores";
@@ -470,6 +478,96 @@ test("A description is not repeated", async () => {
   // description is not a scored item, so the repeat is ignored.
   // Mirrored by "does not repeat a description" in
   // `apps/app/src/utils/activity.cy.tsx`.
+  expect(source.items[0].type).eqls("singleDoc");
+});
+
+test("A document is repeated no more times than it has variants", async () => {
+  const { userId } = await createTestUser();
+  const [ps, psDoc] = await setupTestContent(userId, {
+    ps: pset({
+      psDoc: doc(`<selectFromSequence from="1" to="5"/>`),
+    }),
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    numVariants: 5,
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    repeatInProblemSet: 3,
+  });
+
+  // Editing the document down to fewer variants leaves the larger repeat in
+  // place, and the editor offers no way to lower it: the repeat control is
+  // shown only for a document with more than one variant.
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    numVariants: 2,
+  });
+
+  const content = await getContent({ contentId: ps, loggedInUserId: userId });
+  const source = compileActivityFromContent(content);
+  if (source.type !== "sequence") {
+    throw Error("shouldn't happen");
+  }
+  const item = source.items[0];
+  if (item.type !== "select") {
+    throw Error("shouldn't happen");
+  }
+  expect(item.numToSelect).eqls(2);
+  expect(item.title).eqls("Repeat 2 times");
+
+  // The item names label the gradebook columns, so they follow the same cap.
+  const { assignmentId } = await createAssignment({
+    contentId: ps,
+    loggedInUserId: userId,
+    closedOn: DateTime.now().plus({ days: 1 }),
+    destinationParentId: null,
+  });
+  const { itemNames } = await getAssignmentResponseOverview({
+    contentId: assignmentId,
+    loggedInUserId: userId,
+  });
+  expect(itemNames).eqls(["psDoc (1)", "psDoc (2)"]);
+});
+
+test("A document in a question bank is not repeated", async () => {
+  const { userId } = await createTestUser();
+  const [_ps, psDoc, bank] = await setupTestContent(userId, {
+    ps: pset({
+      psDoc: doc(`<selectFromSequence from="1" to="5"/>`),
+    }),
+    bank: qbank({}),
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    numVariants: 5,
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    repeatInProblemSet: 3,
+  });
+
+  // The setting travels with the document when it moves, but a question bank
+  // already selects from its documents: a nested select would put more items
+  // in the activity than `numToSelect` accounts for.
+  await moveContent({
+    contentId: psDoc,
+    changeParentIdTo: bank,
+    desiredPosition: 0,
+    loggedInUserId: userId,
+  });
+
+  const content = await getContent({ contentId: bank, loggedInUserId: userId });
+  const source = compileActivityFromContent(content);
+  if (source.type !== "select") {
+    throw Error("shouldn't happen");
+  }
   expect(source.items[0].type).eqls("singleDoc");
 });
 

--- a/apps/api/src/test/activity.test.ts
+++ b/apps/api/src/test/activity.test.ts
@@ -436,6 +436,43 @@ test("A description is not one of the scored items", async () => {
   ).eqls([true, false]);
 });
 
+test("A description is not repeated", async () => {
+  const { userId } = await createTestUser();
+  const [ps, psDoc] = await setupTestContent(userId, {
+    ps: pset({
+      psDoc: doc(`<selectFromSequence from="1" to="5"/>`),
+    }),
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    numVariants: 5,
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    repeatInProblemSet: 3,
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    isDescription: true,
+  });
+
+  const content = await getContent({ contentId: ps, loggedInUserId: userId });
+  const source = compileActivityFromContent(content);
+
+  if (source.type !== "sequence") {
+    throw Error("shouldn't happen");
+  }
+
+  // The viewer throws on a select whose items include a description, and a
+  // description is not a scored item, so the repeat is ignored.
+  // Mirrored by "does not repeat a description" in
+  // `apps/app/src/utils/activity.cy.tsx`.
+  expect(source.items[0].type).eqls("singleDoc");
+});
+
 test("deleteContent marks a activity and document as deleted and prevents its retrieval", async () => {
   const user = await createTestUser();
   const userId = user.userId;

--- a/apps/api/src/test/activity.test.ts
+++ b/apps/api/src/test/activity.test.ts
@@ -354,9 +354,6 @@ test("Test updating isDescription", async () => {
 });
 
 test("repeatInProblemSet survives into the compiled activity", async () => {
-  // `repeatInProblemSet` used to be selected only behind an opt-in flag that
-  // most callers left off, so it silently vanished from every compiled
-  // activity except the compound-editor preview.
   const { userId } = await createTestUser();
   const [ps, psDoc] = await setupTestContent(userId, {
     ps: pset({
@@ -374,7 +371,8 @@ test("repeatInProblemSet survives into the compiled activity", async () => {
     repeatInProblemSet: 3,
   });
 
-  // `getContent` without any opt-in flag must still carry the setting
+  // A plain `getContent` must carry the setting, since it is what every
+  // activity-compiling caller (revisions, cids, assignments) uses.
   const content = await getContent({ contentId: ps, loggedInUserId: userId });
   const source = compileActivityFromContent(content);
 

--- a/apps/api/src/test/activity.test.ts
+++ b/apps/api/src/test/activity.test.ts
@@ -43,6 +43,7 @@ import { setContentLicense } from "../query/license";
 import { updateVisibility } from "../access";
 import { fromUUID, isEqualUUID } from "../utils/uuid";
 import { Doc } from "../types";
+import { compileActivityFromContent } from "../utils/contentStructure";
 import {
   InvalidRequestError,
   PermissionDeniedRedirectError,
@@ -275,7 +276,6 @@ test("Test updating repeatInProblemSet", async () => {
     const result = (await getContent({
       contentId: psDoc,
       loggedInUserId: userId,
-      includeRepeatInProblemSet: true,
     })) as Doc;
     return result.repeatInProblemSet;
   }
@@ -306,6 +306,136 @@ test("Test updating repeatInProblemSet", async () => {
     repeatInProblemSet: 24,
   });
   expect(await repeatVal()).eqls(23);
+});
+
+test("Test updating isDescription", async () => {
+  const { userId } = await createTestUser();
+  const [_ps, psDoc, nonPsDoc] = await setupTestContent(userId, {
+    ps: pset({
+      psDoc: doc("a description"),
+    }),
+    nonPsDoc: doc("not inside problem set"),
+  });
+
+  // Cannot update outside of problem set
+  await expect(
+    updateContent({
+      contentId: nonPsDoc,
+      loggedInUserId: userId,
+      isDescription: true,
+    }),
+  ).rejects.toThrowError();
+
+  async function descriptionVal() {
+    const result = (await getContent({
+      contentId: psDoc,
+      loggedInUserId: userId,
+    })) as Doc;
+    return result.isDescription;
+  }
+
+  // Defaults to false
+  expect(await descriptionVal()).eqls(false);
+
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    isDescription: true,
+  });
+  expect(await descriptionVal()).eqls(true);
+
+  // `false` is a meaningful value, not a no-op
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    isDescription: false,
+  });
+  expect(await descriptionVal()).eqls(false);
+});
+
+test("repeatInProblemSet survives into the compiled activity", async () => {
+  // `repeatInProblemSet` used to be selected only behind an opt-in flag that
+  // most callers left off, so it silently vanished from every compiled
+  // activity except the compound-editor preview.
+  const { userId } = await createTestUser();
+  const [ps, psDoc] = await setupTestContent(userId, {
+    ps: pset({
+      psDoc: doc(`<selectFromSequence from="1" to="5"/>`),
+    }),
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    numVariants: 5,
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    repeatInProblemSet: 3,
+  });
+
+  // `getContent` without any opt-in flag must still carry the setting
+  const content = await getContent({ contentId: ps, loggedInUserId: userId });
+  const source = compileActivityFromContent(content);
+
+  if (source.type !== "sequence") {
+    throw Error("shouldn't happen");
+  }
+
+  // the repeated document is wrapped in a select that picks 3 variants.
+  // Mirrored by "wraps a repeated document in a select, as the server does"
+  // in `apps/app/src/utils/activity.cy.tsx` — the client compiler produces the
+  // source for every viewer path, so the two must stay in agreement.
+  const item = source.items[0];
+  expect(item.type).eqls("select");
+  if (item.type !== "select") {
+    throw Error("shouldn't happen");
+  }
+  expect(item.id).eqls(`select_for_${fromUUID(psDoc)}`);
+  expect(item.title).eqls("Repeat 3 times");
+  expect(item.numToSelect).eqls(3);
+  expect(item.selectByVariant).eqls(true);
+  expect(item.items.length).eqls(1);
+
+  const inner = item.items[0];
+  if (inner.type !== "singleDoc") {
+    throw Error("shouldn't happen");
+  }
+  expect(inner.id).eqls(fromUUID(psDoc));
+  // the document carries its title, as it does on the client
+  expect(inner.title).eqls("psDoc");
+});
+
+test("A description is not one of the scored items", async () => {
+  const { userId } = await createTestUser();
+  const [ps, psDoc1, _psDoc2] = await setupTestContent(userId, {
+    ps: pset({
+      psDoc1: doc("intro text"),
+      psDoc2: doc("<problem><answer>1</answer></problem>"),
+    }),
+  });
+
+  await updateContent({
+    contentId: psDoc1,
+    loggedInUserId: userId,
+    isDescription: true,
+  });
+
+  const content = await getContent({ contentId: ps, loggedInUserId: userId });
+  const source = compileActivityFromContent(content);
+
+  if (source.type !== "sequence") {
+    throw Error("shouldn't happen");
+  }
+
+  // both documents are compiled into the activity, but only the second one
+  // counts as a scored item
+  expect(source.items.length).eqls(2);
+  expect(
+    source.items.map((item) =>
+      item.type === "singleDoc" ? item.isDescription : undefined,
+    ),
+  ).eqls([true, false]);
 });
 
 test("deleteContent marks a activity and document as deleted and prevents its retrieval", async () => {

--- a/apps/api/src/test/assign.test.ts
+++ b/apps/api/src/test/assign.test.ts
@@ -7,6 +7,7 @@ import {
   fold,
   getTestAssignment,
   pset,
+  qbank,
   setupTestContent,
 } from "./utils";
 import { DateTime } from "luxon";
@@ -622,6 +623,54 @@ test("cannot assign sub-part of problem set", async () => {
       destinationParentId: null,
     }),
   ).rejects.toThrow();
+});
+
+test("item names skip descriptions and expand question banks and repeats", async () => {
+  const owner = await createTestUser();
+  const ownerId = owner.userId;
+
+  const [psId, introId, problemId, _bankId] = await setupTestContent(ownerId, {
+    "A problem set": pset({
+      Intro: doc("read this first"),
+      Problem: doc(`<selectFromSequence from="1" to="5"/>`),
+      Bank: qbank({
+        "Question A": doc("a"),
+        "Question B": doc("b"),
+      }),
+    }),
+  });
+
+  await updateContent({
+    contentId: introId,
+    loggedInUserId: ownerId,
+    isDescription: true,
+  });
+  await updateContent({
+    contentId: problemId,
+    loggedInUserId: ownerId,
+    numVariants: 5,
+  });
+  await updateContent({
+    contentId: problemId,
+    loggedInUserId: ownerId,
+    repeatInProblemSet: 2,
+  });
+
+  const { assignmentId } = await createAssignment({
+    contentId: psId,
+    loggedInUserId: ownerId,
+    closedOn: DateTime.now().plus({ days: 1 }),
+    destinationParentId: null,
+  });
+
+  // The item names label the gradebook columns, so they must line up one-to-one
+  // with the items of the compiled activity: the description contributes none,
+  // the twice-repeated problem two, and the question bank one per selection.
+  const { itemNames } = await getAssignmentResponseOverview({
+    contentId: assignmentId,
+    loggedInUserId: ownerId,
+  });
+  expect(itemNames).eqls(["Problem (1)", "Problem (2)", "Bank"]);
 });
 
 test("cannot change closedOn, maxAttempts, mode, individualizeByStudent of a non-root assignment activity", async () => {

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -221,11 +221,15 @@ export type Doc = ContentBase & {
   doenetML: string;
   doenetmlVersion: DoenetmlVersion;
   repeatInProblemSet?: number;
+  /**
+   * A description is rendered like any other document in a problem set but is
+   * not one of the scored items: no problem number, no credit, no item state.
+   */
+  isDescription?: boolean;
 };
 
 export type QuestionBank = ContentBase & {
   type: "select";
-  activityJson?: string;
   revisionNum?: number;
   numToSelect: number;
   selectByVariant: boolean;
@@ -234,7 +238,6 @@ export type QuestionBank = ContentBase & {
 
 export type ProblemSet = ContentBase & {
   type: "sequence";
-  activityJson?: string;
   revisionNum?: number;
   shuffle: boolean;
   paginate: boolean;

--- a/apps/api/src/utils/contentStructure.ts
+++ b/apps/api/src/utils/contentStructure.ts
@@ -649,25 +649,36 @@ export function returnClassificationListSelect() {
  * rather than the full doenetml version. Useful for generating a cid from the source
  * that won't change if we upgrade the minor version for all documents (though it does not
  * produce a valid source for viewing the activity).
+ *
+ * `inProblemSet` says whether `activity` is a child of a problem set, which is
+ * where the document settings `isDescription` and `repeatInProblemSet` apply.
  */
 export function compileActivityFromContent(
   activity: Content,
   useVersionIds = false,
+  inProblemSet = false,
 ): ActivitySource {
   switch (activity.type) {
     case "singleDoc": {
+      const isDescription = inProblemSet && (activity.isDescription ?? false);
       const documentJson = {
         id: fromUUID(activity.contentId),
         type: activity.type,
         title: activity.name,
-        isDescription: activity.isDescription ?? false,
+        isDescription,
         doenetML: activity.doenetML!,
         version: useVersionIds
           ? activity.doenetmlVersion.id.toString()
           : activity.doenetmlVersion.fullVersion,
         numVariants: activity.numVariants,
       };
-      if (activity.repeatInProblemSet && activity.repeatInProblemSet > 1) {
+      // A description is not a scored item, so it is never repeated: the viewer
+      // does not support a select whose items include a description.
+      if (
+        !isDescription &&
+        activity.repeatInProblemSet &&
+        activity.repeatInProblemSet > 1
+      ) {
         // If the document repeats, wrap this document in
         // a `select` which can select that many variants.
         return {
@@ -690,7 +701,7 @@ export function compileActivityFromContent(
         numToSelect: activity.numToSelect,
         selectByVariant: activity.selectByVariant,
         items: activity.children.map((child) =>
-          compileActivityFromContent(child, useVersionIds),
+          compileActivityFromContent(child, useVersionIds, false),
         ),
       };
     }
@@ -701,7 +712,7 @@ export function compileActivityFromContent(
         title: activity.name,
         shuffle: activity.shuffle,
         items: activity.children.map((child) =>
-          compileActivityFromContent(child, useVersionIds),
+          compileActivityFromContent(child, useVersionIds, true),
         ),
       };
     }

--- a/apps/api/src/utils/contentStructure.ts
+++ b/apps/api/src/utils/contentStructure.ts
@@ -643,6 +643,29 @@ export function returnClassificationListSelect() {
 }
 
 /**
+ * The number of copies of a document that a problem set contains.
+ *
+ * A description is not a scored item, so it is never repeated. Otherwise the
+ * document is repeated `repeatInProblemSet` times, capped by the number of
+ * variants it has: each copy uses a different variant, and `numVariants` can
+ * drop below a previously saved `repeatInProblemSet` (by editing the source or
+ * reverting the document to an earlier revision).
+ */
+export function repeatCountInProblemSet(doc: {
+  isDescription?: boolean;
+  repeatInProblemSet?: number;
+  numVariants?: number;
+}) {
+  if (doc.isDescription) {
+    return 1;
+  }
+  return Math.max(
+    1,
+    Math.min(doc.repeatInProblemSet ?? 1, doc.numVariants ?? 1),
+  );
+}
+
+/**
  * Compile an `activity` into the activity json used for viewing composite activities.
  *
  * If `useVersionId` is `true`, then compile the activity json where use doenetmlVersionId
@@ -672,20 +695,17 @@ export function compileActivityFromContent(
           : activity.doenetmlVersion.fullVersion,
         numVariants: activity.numVariants,
       };
-      // A description is not a scored item, so it is never repeated: the viewer
-      // does not support a select whose items include a description.
-      if (
-        !isDescription &&
-        activity.repeatInProblemSet &&
-        activity.repeatInProblemSet > 1
-      ) {
+      const repeatCount = inProblemSet
+        ? repeatCountInProblemSet({ ...activity, isDescription })
+        : 1;
+      if (repeatCount > 1) {
         // If the document repeats, wrap this document in
         // a `select` which can select that many variants.
         return {
           id: `select_for_${fromUUID(activity.contentId)}`,
           type: "select",
-          title: `Repeat ${activity.repeatInProblemSet} times`,
-          numToSelect: activity.repeatInProblemSet,
+          title: `Repeat ${repeatCount} times`,
+          numToSelect: repeatCount,
           selectByVariant: true,
           items: [documentJson],
         };

--- a/apps/api/src/utils/contentStructure.ts
+++ b/apps/api/src/utils/contentStructure.ts
@@ -151,7 +151,6 @@ export function returnContentSelect({
   includeClassifications = false,
   includeShareDetails = false,
   includeOwnerDetails = false,
-  includeRepeatInProblemSet = false,
 }) {
   const sharedWith = {
     select: includeShareDetails
@@ -253,10 +252,17 @@ export function returnContentSelect({
     _count: { select: { contentStates: true } },
   };
 
+  // Settings for a document inside a problem set. Both determine the item
+  // structure of the compiled activity, so they must be present every time an
+  // activity is compiled — including for revisions, cids, and assigned
+  // content. They were previously gated behind a flag that most callers left
+  // off, which silently dropped them.
   const docSelect = {
     numVariants: true,
     source: true,
     doenetmlVersion: true,
+    isDescription: true,
+    repeatInProblemSet: true,
   };
 
   const questionBankSelect = {
@@ -269,16 +275,11 @@ export function returnContentSelect({
     paginate: true,
   };
 
-  const repeatInProblemSetSelect = includeRepeatInProblemSet && {
-    repeatInProblemSet: true,
-  };
-
   return {
     ...baseSelect,
     ...docSelect,
     ...questionBankSelect,
     ...problemSetSelect,
-    ...repeatInProblemSetSelect,
     ...assignmentSelect,
   };
 }
@@ -355,6 +356,7 @@ type PreliminaryContent = {
   activityLevelAttempts: boolean;
   itemLevelAttempts: boolean;
   repeatInProblemSet?: number;
+  isDescription?: boolean;
 
   // Assignment related fields
   classCode: number | null;
@@ -466,6 +468,7 @@ export function processContent(
 
     // document inside problem set
     repeatInProblemSet,
+    isDescription,
 
     // Image-only 1:1 data, re-exposed (as `imageSource` + attribution) on the
     // image case below and kept off every other content type.
@@ -523,6 +526,7 @@ export function processContent(
         doenetmlVersion: DoenetmlVersion;
         revisionNum?: number;
         repeatInProblemSet?: number;
+        isDescription: boolean;
       };
 
       if (
@@ -535,6 +539,7 @@ export function processContent(
           numVariants: numVariantsOrig,
           doenetmlVersion: doenetmlVersionOrig,
           repeatInProblemSet,
+          isDescription: isDescription ?? false,
         };
       } else {
         throw new InvalidRequestError("Invalid document");
@@ -655,7 +660,8 @@ export function compileActivityFromContent(
       const documentJson = {
         id: fromUUID(activity.contentId),
         type: activity.type,
-        isDescription: false,
+        title: activity.name,
+        isDescription: activity.isDescription ?? false,
         doenetML: activity.doenetML!,
         version: useVersionIds
           ? activity.doenetmlVersion.id.toString()

--- a/apps/api/src/utils/contentStructure.ts
+++ b/apps/api/src/utils/contentStructure.ts
@@ -15,7 +15,7 @@ import {
 import { sortClassifications } from "./classificationsCategories";
 import { fromUUID, isEqualUUID } from "./uuid";
 import { DateTime } from "luxon";
-import { ActivitySource } from "@doenet-tools/shared";
+import { ActivitySource, repeatCountInProblemSet } from "@doenet-tools/shared";
 import { InvalidRequestError } from "./error";
 import { imageSourceFromStorageKey } from "../media/upload.schema";
 
@@ -640,29 +640,6 @@ export function returnClassificationListSelect() {
       orderBy: { isPrimary: "desc" as const },
     },
   };
-}
-
-/**
- * The number of copies of a document that a problem set contains.
- *
- * A description is not a scored item, so it is never repeated. Otherwise the
- * document is repeated `repeatInProblemSet` times, capped by the number of
- * variants it has: each copy uses a different variant, and `numVariants` can
- * drop below a previously saved `repeatInProblemSet` (by editing the source or
- * reverting the document to an earlier revision).
- */
-export function repeatCountInProblemSet(doc: {
-  isDescription?: boolean;
-  repeatInProblemSet?: number;
-  numVariants?: number;
-}) {
-  if (doc.isDescription) {
-    return 1;
-  }
-  return Math.max(
-    1,
-    Math.min(doc.repeatInProblemSet ?? 1, doc.numVariants ?? 1),
-  );
 }
 
 /**

--- a/apps/api/src/utils/contentStructure.ts
+++ b/apps/api/src/utils/contentStructure.ts
@@ -252,11 +252,10 @@ export function returnContentSelect({
     _count: { select: { contentStates: true } },
   };
 
-  // Settings for a document inside a problem set. Both determine the item
-  // structure of the compiled activity, so they must be present every time an
-  // activity is compiled — including for revisions, cids, and assigned
-  // content. They were previously gated behind a flag that most callers left
-  // off, which silently dropped them.
+  // `isDescription` and `repeatInProblemSet` are settings for a document inside
+  // a problem set. Both determine the item structure of the compiled activity,
+  // so they are always selected: every caller that compiles an activity —
+  // including for revisions, cids, and assigned content — needs them.
   const docSelect = {
     numVariants: true,
     source: true,

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -29,7 +29,7 @@
     "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/react": "^2.10.9",
     "@doenet-tools/shared": "*",
-    "@doenet/assignment-viewer": "^0.1.0-alpha-17",
+    "@doenet/assignment-viewer": "^0.1.0-alpha-18",
     "@doenet/doenetml-iframe": "^0.7.24",
     "@doenet/v06-to-v07": "^0.7.24",
     "@fontsource/jost": "^5.2.6",

--- a/apps/app/src/paths/ActivityViewer.tsx
+++ b/apps/app/src/paths/ActivityViewer.tsx
@@ -66,7 +66,7 @@ import {
   getIconInfo,
   menuIcons,
 } from "../utils/activity";
-import { ActivitySource, isActivitySource } from "@doenet-tools/shared";
+import { ActivitySource } from "@doenet-tools/shared";
 import { DoenetEditor, DoenetViewer } from "@doenet/doenetml-iframe";
 import { doenetImagesUrl } from "../utils/media";
 import { ActivityViewer as DoenetActivityViewer } from "@doenet/assignment-viewer";
@@ -114,13 +114,7 @@ export async function loader({ params }: { params: any }) {
       libraryRelations,
     };
   } else {
-    const activityJsonFromRevision = activityData.activityJson
-      ? JSON.parse(activityData.activityJson)
-      : null;
-
-    const activityJson = isActivitySource(activityJsonFromRevision)
-      ? activityJsonFromRevision
-      : compileActivityFromContent(activityData);
+    const activityJson = compileActivityFromContent(activityData);
 
     return {
       type: activityData.type,

--- a/apps/app/src/paths/AssignmentResponseOverview.tsx
+++ b/apps/app/src/paths/AssignmentResponseOverview.tsx
@@ -45,7 +45,6 @@ import {
   DoenetmlVersion,
   UserInfoWithEmail,
 } from "../types";
-import { isActivitySource } from "@doenet/assignment-viewer";
 import {
   compileActivityFromContent,
   contentTypeToName,
@@ -173,13 +172,7 @@ export async function loader({ params, request }: ActionFunctionArgs) {
       doenetmlVersion,
     };
   } else if (assignment.type !== "folder" && assignment.type !== "image") {
-    const activityJsonPrelim = assignment.activityJson
-      ? JSON.parse(assignment.activityJson)
-      : null;
-
-    const activityJson = isActivitySource(activityJsonPrelim)
-      ? activityJsonPrelim
-      : compileActivityFromContent(assignment);
+    const activityJson = compileActivityFromContent(assignment);
 
     const itemNames = data.itemNames;
 

--- a/apps/app/src/paths/AssignmentViewer.tsx
+++ b/apps/app/src/paths/AssignmentViewer.tsx
@@ -17,11 +17,7 @@ import {
 } from "./EnterClassCode";
 import { SiteContext } from "./SiteHeader";
 import { Content, DoenetmlVersion } from "../types";
-import {
-  ActivitySource,
-  isActivitySource,
-  isReportStateMessage,
-} from "@doenet-tools/shared";
+import { ActivitySource, isReportStateMessage } from "@doenet-tools/shared";
 import { compileActivityFromContent } from "../utils/activity";
 import { ActivityViewer as DoenetActivityViewer } from "@doenet/assignment-viewer";
 import { effectiveDarkMode, useThemeSettingContext } from "../utils/theme";
@@ -188,13 +184,7 @@ export async function loader({ params }: { params: any }) {
       loadedScore,
     };
   } else {
-    const activityJsonPrelim = data.assignment.activityJson
-      ? JSON.parse(data.assignment.activityJson)
-      : null;
-
-    const activityJson = isActivitySource(activityJsonPrelim)
-      ? activityJsonPrelim
-      : compileActivityFromContent(data.assignment);
+    const activityJson = compileActivityFromContent(data.assignment);
 
     return {
       assignmentFound: true,

--- a/apps/app/src/paths/RawViewer.tsx
+++ b/apps/app/src/paths/RawViewer.tsx
@@ -35,13 +35,7 @@ export async function loader({ params }: any) {
         contentId,
       };
     } else {
-      const activityJsonFromRevision = activityData.activityJson
-        ? JSON.parse(activityData.activityJson)
-        : null;
-
-      const activityJson = isActivitySource(activityJsonFromRevision)
-        ? activityJsonFromRevision
-        : compileActivityFromContent(activityData);
+      const activityJson = compileActivityFromContent(activityData);
 
       return {
         type: activityData.type,

--- a/apps/app/src/popups/CopyContentAndReportFinish.cy.tsx
+++ b/apps/app/src/popups/CopyContentAndReportFinish.cy.tsx
@@ -536,5 +536,35 @@ describe(
         cy.checkAccessibility("body");
       });
     });
+
+    // `fetcher` is shared with the rest of the editor. Saving a per-document
+    // setting (e.g. the Description checkbox) while this modal is mounted puts
+    // a foreign 200 on it — one with no `newContentIds`. Treating that as the
+    // copy's own result used to crash the render with
+    // "Cannot read properties of undefined (reading 'length')".
+    it("ignores a 200 on the shared fetcher that is not its own result", () => {
+      const foreignResponse = createMockFetcher({
+        status: 200,
+        data: { contentId: "some-doc", isDescription: true },
+      });
+
+      cy.mount(
+        <CopyContentAndReportFinish
+          isOpen={true}
+          onClose={cy.spy().as("onClose")}
+          contentIds={["content1"]}
+          desiredParent={mockParentSequence}
+          action="Add"
+          fetcher={foreignResponse}
+          user={mockUser}
+          setAddTo={cy.spy().as("setAddTo")}
+          onNavigate={cy.spy().as("onNavigate")}
+        />,
+      );
+
+      // still waiting on its own result rather than crashing or claiming success
+      cy.get('[data-test="Copy Header"]').should("have.text", "Adding");
+      cy.contains("item added to").should("not.exist");
+    });
   },
 );

--- a/apps/app/src/popups/CopyContentAndReportFinish.tsx
+++ b/apps/app/src/popups/CopyContentAndReportFinish.tsx
@@ -57,7 +57,13 @@ export function CopyContentAndReportFinish({
   useEffect(() => {
     if (fetcher.data) {
       if (fetcher.data.status === 200) {
-        setNewContentIds(fetcher.data.data.newContentIds);
+        // `fetcher` is shared with the rest of the editor, so a 200 here is not
+        // necessarily this copy's result. Only a response actually carrying
+        // `newContentIds` is ours; anything else is another submission's.
+        const ids = fetcher.data.data?.newContentIds;
+        if (Array.isArray(ids)) {
+          setNewContentIds(ids);
+        }
       } else {
         const message = fetcher.data.message;
         setErrMsg(

--- a/apps/app/src/popups/MoveCopyContent.cy.tsx
+++ b/apps/app/src/popups/MoveCopyContent.cy.tsx
@@ -633,4 +633,53 @@ describe("MoveCopyContent component tests", { tags: ["@group2"] }, () => {
       cy.checkAccessibility("body");
     });
   });
+
+  // `fetcher` is shared with the rest of the page, so a settings save or any
+  // other submission can land a 200 on it while this modal is mounted. A move
+  // returns no payload, so the response cannot be recognized — the modal must
+  // only react to a result it actually asked for. Reacting to a foreign one
+  // used to report a completed action, and crash on the Copy path reading
+  // `data.newContentIds.length` of undefined.
+  it("ignores a result on the shared fetcher that it did not ask for", () => {
+    cy.intercept("/api/copyMove/getMoveCopyContentData/*", {
+      parent: null,
+      contents: contentList1,
+    }).as("getData");
+
+    const foreignResult = {
+      state: "idle",
+      formData: undefined,
+      data: {
+        status: 200,
+        data: { contentId: "some-doc", isDescription: true },
+      },
+      Form: ({ children }: any) => <form>{children}</form>,
+      submit: () => {},
+      load: () => {},
+    } as unknown as FetcherWithComponents<any>;
+
+    cy.mount(
+      <MoveCopyContent
+        isOpen={true}
+        onClose={cy.spy().as("onClose")}
+        onNavigate={cy.spy().as("onNavigate")}
+        fetcher={foreignResult}
+        sourceContent={[{ contentId, name: contentName, type: contentType }]}
+        userId={"abc123"}
+        currentParentId={null}
+        allowedParentTypes={["folder"]}
+        action="Copy"
+      />,
+    );
+
+    cy.wait("@getData");
+
+    // still offering the action rather than claiming it finished
+    cy.get('[data-test="Execute MoveCopy Button"]').should("be.visible");
+    cy.get('[data-test="Go to Destination"]').should("not.exist");
+    cy.get('[data-test="MoveCopy Body"]').should(
+      "not.contain.text",
+      "copied to",
+    );
+  });
 });

--- a/apps/app/src/popups/MoveCopyContent.tsx
+++ b/apps/app/src/popups/MoveCopyContent.tsx
@@ -106,6 +106,7 @@ export function MoveCopyContent({
     }
     setActionFinished(false);
     setErrMsg("");
+    awaitingOwnResult.current = false;
     // TODO: proper way to have functions and hooks
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, currentParentId]);
@@ -142,16 +143,23 @@ export function MoveCopyContent({
 
   const initialRef = useRef<HTMLButtonElement>(null);
 
+  // `fetcher` is shared with the rest of the page, so a response on it is not
+  // necessarily this modal's. A move returns no payload, so there is nothing in
+  // the response to recognize — track who started the submission instead.
+  const awaitingOwnResult = useRef(false);
+
   useEffect(() => {
-    if (fetcher.data && fetcher.data.status === 200) {
+    if (!fetcher.data || !awaitingOwnResult.current) {
+      return;
+    }
+    awaitingOwnResult.current = false;
+
+    if (fetcher.data.status === 200) {
       setActionFinished(true);
-      if (action === "Move") {
-        setNumItems(1);
-      } else {
-        const numItems: number = fetcher.data.data.newContentIds.length;
-        setNumItems(numItems);
-      }
-    } else if (fetcher.data && fetcher.data.success === false) {
+      setNumItems(
+        action === "Move" ? 1 : (fetcher.data.data?.newContentIds?.length ?? 0),
+      );
+    } else if (fetcher.data.success === false) {
       setErrMsg(fetcher.data.message);
     }
   }, [fetcher.data, action]);
@@ -456,6 +464,7 @@ export function MoveCopyContent({
 
     if (action === "Move") {
       if (contentIds.length === 1) {
+        awaitingOwnResult.current = true;
         fetcher.submit(
           {
             path: `copyMove/moveContent`,
@@ -469,6 +478,7 @@ export function MoveCopyContent({
         throw Error("Have not implemented moving more than one content");
       }
     } else if (action === "Copy" || action === "Add") {
+      awaitingOwnResult.current = true;
       fetcher.submit(
         {
           path: "copyMove/copyContent",

--- a/apps/app/src/types.ts
+++ b/apps/app/src/types.ts
@@ -190,11 +190,15 @@ export type Doc = ContentBase & {
   doenetML: string;
   doenetmlVersion: DoenetmlVersion;
   repeatInProblemSet?: number;
+  /**
+   * A description is rendered like any other document in a problem set but is
+   * not one of the scored items: no problem number, no credit, no item state.
+   */
+  isDescription?: boolean;
 };
 
 export type QuestionBank = ContentBase & {
   type: "select";
-  activityJson?: string;
   revisionNum?: number;
   numToSelect: number;
   selectByVariant: boolean;
@@ -203,7 +207,6 @@ export type QuestionBank = ContentBase & {
 
 export type ProblemSet = ContentBase & {
   type: "sequence";
-  activityJson?: string;
   revisionNum?: number;
   shuffle: boolean;
   paginate: boolean;

--- a/apps/app/src/utils/activity.cy.tsx
+++ b/apps/app/src/utils/activity.cy.tsx
@@ -6,8 +6,9 @@ import { Content } from "../types";
 // function, while revisions and cids are compiled by the server twin in
 // `apps/api/src/utils/contentStructure.ts`. The two must agree, or the same
 // problem set renders differently depending on how it is opened. The
-// assertions here are mirrored by "problem set compiles the same way on the
-// client and the server" in `apps/api/src/test/activity.test.ts`.
+// assertions here are mirrored by "repeatInProblemSet survives into the
+// compiled activity" and "A description is not one of the scored items" in
+// `apps/api/src/test/activity.test.ts`.
 
 function mkDoc(
   contentId: string,

--- a/apps/app/src/utils/activity.cy.tsx
+++ b/apps/app/src/utils/activity.cy.tsx
@@ -91,6 +91,43 @@ describe("compileActivityFromContent", { tags: ["@group4"] }, () => {
     expect(item.items[0].id).to.equal("doc1");
   });
 
+  it("does not repeat a description", () => {
+    // The viewer throws on a select whose items include a description
+    // ("The case where a select contains a description is not implemented"),
+    // and a description is not a scored item, so it never repeats.
+    const source = compileActivityFromContent(
+      mkProblemSet([
+        mkDoc("doc1", "Intro", { isDescription: true, repeatInProblemSet: 3 }),
+      ]),
+    );
+    if (source.type !== "sequence") {
+      throw Error("expected a sequence");
+    }
+    expect(source.items[0].type).to.equal("singleDoc");
+  });
+
+  it("ignores isDescription outside a problem set", () => {
+    // `isDescription` is a setting for a document in a problem set; a document
+    // that carries the flag into a question bank is a normal scored item.
+    const source = compileActivityFromContent({
+      contentId: "bank",
+      name: "My question bank",
+      type: "select",
+      numToSelect: 1,
+      selectByVariant: false,
+      children: [mkDoc("doc1", "Intro", { isDescription: true })],
+    } as unknown as Content);
+
+    if (source.type !== "select") {
+      throw Error("expected a select");
+    }
+    const item = source.items[0];
+    if (item.type !== "singleDoc") {
+      throw Error("expected a singleDoc");
+    }
+    expect(item.isDescription).to.equal(false);
+  });
+
   it("does not wrap when the document repeats once", () => {
     const source = compileActivityFromContent(
       mkProblemSet([mkDoc("doc1", "Problem", { repeatInProblemSet: 1 })]),

--- a/apps/app/src/utils/activity.cy.tsx
+++ b/apps/app/src/utils/activity.cy.tsx
@@ -1,0 +1,104 @@
+import { compileActivityFromContent } from "./activity";
+import { Content } from "../types";
+
+// Every viewer path (ActivityViewer, AssignmentViewer, RawViewer,
+// AssignmentResponseOverview) compiles the activity source with *this*
+// function, while revisions and cids are compiled by the server twin in
+// `apps/api/src/utils/contentStructure.ts`. The two must agree, or the same
+// problem set renders differently depending on how it is opened. The
+// assertions here are mirrored by "problem set compiles the same way on the
+// client and the server" in `apps/api/src/test/activity.test.ts`.
+
+function mkDoc(
+  contentId: string,
+  name: string,
+  extra: Partial<Content> = {},
+): Content {
+  return {
+    contentId,
+    name,
+    type: "singleDoc",
+    doenetML: `<p>${name}</p>`,
+    doenetmlVersion: { fullVersion: "0.7.24" },
+    numVariants: 5,
+    ...extra,
+  } as unknown as Content;
+}
+
+function mkProblemSet(children: Content[]): Content {
+  return {
+    contentId: "ps",
+    name: "My problem set",
+    type: "sequence",
+    shuffle: false,
+    children,
+  } as unknown as Content;
+}
+
+describe("compileActivityFromContent", { tags: ["@group4"] }, () => {
+  it("compiles a document with its title and description flag", () => {
+    const source = compileActivityFromContent(
+      mkProblemSet([mkDoc("doc1", "Intro", { isDescription: true })]),
+    );
+
+    if (source.type !== "sequence") {
+      throw Error("expected a sequence");
+    }
+    expect(source.items[0]).to.deep.equal({
+      id: "doc1",
+      type: "singleDoc",
+      title: "Intro",
+      isDescription: true,
+      doenetML: "<p>Intro</p>",
+      version: "0.7.24",
+      numVariants: 5,
+    });
+  });
+
+  it("defaults isDescription to false", () => {
+    const source = compileActivityFromContent(
+      mkProblemSet([mkDoc("doc1", "Problem")]),
+    );
+    if (source.type !== "sequence") {
+      throw Error("expected a sequence");
+    }
+    const item = source.items[0];
+    if (item.type !== "singleDoc") {
+      throw Error("expected a singleDoc");
+    }
+    expect(item.isDescription).to.equal(false);
+  });
+
+  it("wraps a repeated document in a select, as the server does", () => {
+    const source = compileActivityFromContent(
+      mkProblemSet([mkDoc("doc1", "Problem", { repeatInProblemSet: 3 })]),
+    );
+
+    if (source.type !== "sequence") {
+      throw Error("expected a sequence");
+    }
+    const item = source.items[0];
+    if (item.type !== "select") {
+      throw Error("expected a repeated document to compile to a select");
+    }
+
+    expect(item.id).to.equal("select_for_doc1");
+    expect(item.title).to.equal("Repeat 3 times");
+    expect(item.numToSelect).to.equal(3);
+    expect(item.selectByVariant).to.equal(true);
+    expect(item.items).to.have.length(1);
+    expect(item.items[0].id).to.equal("doc1");
+  });
+
+  it("does not wrap when the document repeats once", () => {
+    const source = compileActivityFromContent(
+      mkProblemSet([mkDoc("doc1", "Problem", { repeatInProblemSet: 1 })]),
+    );
+    if (source.type !== "sequence") {
+      throw Error("expected a sequence");
+    }
+    // A repeat of 1 must compile identically to no repeat at all, so that
+    // existing saved student state keeps its source hash.
+    expect(source.items[0].type).to.equal("singleDoc");
+  });
+});

--- a/apps/app/src/utils/activity.cy.tsx
+++ b/apps/app/src/utils/activity.cy.tsx
@@ -139,4 +139,57 @@ describe("compileActivityFromContent", { tags: ["@group4"] }, () => {
     // existing saved student state keeps its source hash.
     expect(source.items[0].type).to.equal("singleDoc");
   });
+
+  it("does not repeat a document inside a question bank", () => {
+    // The bank already selects `numToSelect` of its documents, and the item
+    // names count it as exactly that many items, so a nested select would put
+    // more items in the activity than the gradebook has columns for. The
+    // setting travels with a document copied out of a problem set, so the
+    // compiler cannot assume it is absent here.
+    const source = compileActivityFromContent({
+      contentId: "bank",
+      name: "My question bank",
+      type: "select",
+      numToSelect: 1,
+      selectByVariant: false,
+      children: [mkDoc("doc1", "Problem", { repeatInProblemSet: 3 })],
+    } as unknown as Content);
+
+    if (source.type !== "select") {
+      throw Error("expected a select");
+    }
+    expect(source.items[0].type).to.equal("singleDoc");
+  });
+
+  it("repeats no more copies than the document has variants", () => {
+    // Editing or reverting a document can lower `numVariants` below a repeat
+    // saved earlier, and the editor then hides the repeat control (it is shown
+    // only for multi-variant documents), so nothing else would correct it.
+    const source = compileActivityFromContent(
+      mkProblemSet([
+        mkDoc("doc1", "Problem", { repeatInProblemSet: 3, numVariants: 2 }),
+      ]),
+    );
+    if (source.type !== "sequence") {
+      throw Error("expected a sequence");
+    }
+    const item = source.items[0];
+    if (item.type !== "select") {
+      throw Error("expected a select");
+    }
+    expect(item.numToSelect).to.equal(2);
+    expect(item.title).to.equal("Repeat 2 times");
+  });
+
+  it("does not wrap a repeated document that has only one variant", () => {
+    const source = compileActivityFromContent(
+      mkProblemSet([
+        mkDoc("doc1", "Problem", { repeatInProblemSet: 3, numVariants: 1 }),
+      ]),
+    );
+    if (source.type !== "sequence") {
+      throw Error("expected a sequence");
+    }
+    expect(source.items[0].type).to.equal("singleDoc");
+  });
 });

--- a/apps/app/src/utils/activity.ts
+++ b/apps/app/src/utils/activity.ts
@@ -11,7 +11,7 @@ import {
   ContentType,
   DoenetmlVersion,
 } from "../types";
-import { ActivitySource } from "@doenet-tools/shared";
+import { ActivitySource, repeatCountInProblemSet } from "@doenet-tools/shared";
 import { IconType } from "react-icons/lib";
 import { FaFolder, FaImage } from "react-icons/fa";
 import { FaListOl } from "react-icons/fa6";
@@ -115,29 +115,6 @@ export function findClassificationDescriptionIndex({
     }
     return c.subCategory === subCategory;
   });
-}
-
-/**
- * The number of copies of a document that a problem set contains.
- *
- * A description is not a scored item, so it is never repeated. Otherwise the
- * document is repeated `repeatInProblemSet` times, capped by the number of
- * variants it has: each copy uses a different variant, and `numVariants` can
- * drop below a previously saved `repeatInProblemSet` (by editing the source or
- * reverting the document to an earlier revision).
- */
-function repeatCountInProblemSet(doc: {
-  isDescription?: boolean;
-  repeatInProblemSet?: number;
-  numVariants?: number;
-}) {
-  if (doc.isDescription) {
-    return 1;
-  }
-  return Math.max(
-    1,
-    Math.min(doc.repeatInProblemSet ?? 1, doc.numVariants ?? 1),
-  );
 }
 
 /**

--- a/apps/app/src/utils/activity.ts
+++ b/apps/app/src/utils/activity.ts
@@ -117,24 +117,41 @@ export function findClassificationDescriptionIndex({
   });
 }
 
-export function compileActivityFromContent(activity: Content): ActivitySource {
+/**
+ * Compile an `activity` into the activity json used for viewing composite activities.
+ *
+ * `inProblemSet` says whether `activity` is a child of a problem set, which is
+ * where the document settings `isDescription` and `repeatInProblemSet` apply.
+ *
+ * Must stay in sync with the server compiler in
+ * `apps/api/src/utils/contentStructure.ts`, since the two produce the source
+ * for different views of the same problem set.
+ */
+export function compileActivityFromContent(
+  activity: Content,
+  inProblemSet = false,
+): ActivitySource {
   switch (activity.type) {
     case "singleDoc": {
+      const isDescription = inProblemSet && (activity.isDescription ?? false);
       const documentJson = {
         id: activity.contentId,
         type: activity.type,
         title: activity.name,
-        isDescription: activity.isDescription ?? false,
+        isDescription,
         doenetML: activity.doenetML,
         version: activity.doenetmlVersion.fullVersion,
         numVariants: activity.numVariants,
       };
-      if (activity.repeatInProblemSet && activity.repeatInProblemSet > 1) {
+      // A description is not a scored item, so it is never repeated: the viewer
+      // does not support a select whose items include a description.
+      if (
+        !isDescription &&
+        activity.repeatInProblemSet &&
+        activity.repeatInProblemSet > 1
+      ) {
         // If the document repeats, wrap this document in
         // a `select` which can select that many variants.
-        // Must stay in sync with the server compiler in
-        // `apps/api/src/utils/contentStructure.ts`, since the two produce the
-        // source for different views of the same problem set.
         return {
           id: `select_for_${activity.contentId}`,
           type: "select",
@@ -154,7 +171,9 @@ export function compileActivityFromContent(activity: Content): ActivitySource {
         title: activity.name,
         numToSelect: activity.numToSelect,
         selectByVariant: activity.selectByVariant,
-        items: activity.children.map(compileActivityFromContent),
+        items: activity.children.map((child) =>
+          compileActivityFromContent(child, false),
+        ),
       };
     }
     case "sequence": {
@@ -163,7 +182,9 @@ export function compileActivityFromContent(activity: Content): ActivitySource {
         type: activity.type,
         title: activity.name,
         shuffle: activity.shuffle,
-        items: activity.children.map(compileActivityFromContent),
+        items: activity.children.map((child) =>
+          compileActivityFromContent(child, true),
+        ),
       };
     }
     case "folder": {

--- a/apps/app/src/utils/activity.ts
+++ b/apps/app/src/utils/activity.ts
@@ -118,6 +118,29 @@ export function findClassificationDescriptionIndex({
 }
 
 /**
+ * The number of copies of a document that a problem set contains.
+ *
+ * A description is not a scored item, so it is never repeated. Otherwise the
+ * document is repeated `repeatInProblemSet` times, capped by the number of
+ * variants it has: each copy uses a different variant, and `numVariants` can
+ * drop below a previously saved `repeatInProblemSet` (by editing the source or
+ * reverting the document to an earlier revision).
+ */
+function repeatCountInProblemSet(doc: {
+  isDescription?: boolean;
+  repeatInProblemSet?: number;
+  numVariants?: number;
+}) {
+  if (doc.isDescription) {
+    return 1;
+  }
+  return Math.max(
+    1,
+    Math.min(doc.repeatInProblemSet ?? 1, doc.numVariants ?? 1),
+  );
+}
+
+/**
  * Compile an `activity` into the activity json used for viewing composite activities.
  *
  * `inProblemSet` says whether `activity` is a child of a problem set, which is
@@ -143,20 +166,17 @@ export function compileActivityFromContent(
         version: activity.doenetmlVersion.fullVersion,
         numVariants: activity.numVariants,
       };
-      // A description is not a scored item, so it is never repeated: the viewer
-      // does not support a select whose items include a description.
-      if (
-        !isDescription &&
-        activity.repeatInProblemSet &&
-        activity.repeatInProblemSet > 1
-      ) {
+      const repeatCount = inProblemSet
+        ? repeatCountInProblemSet({ ...activity, isDescription })
+        : 1;
+      if (repeatCount > 1) {
         // If the document repeats, wrap this document in
         // a `select` which can select that many variants.
         return {
           id: `select_for_${activity.contentId}`,
           type: "select",
-          title: `Repeat ${activity.repeatInProblemSet} times`,
-          numToSelect: activity.repeatInProblemSet,
+          title: `Repeat ${repeatCount} times`,
+          numToSelect: repeatCount,
           selectByVariant: true,
           items: [documentJson],
         };

--- a/apps/app/src/utils/activity.ts
+++ b/apps/app/src/utils/activity.ts
@@ -1,6 +1,7 @@
 import { TbPuzzle } from "react-icons/tb";
 import {
   MdAssignment,
+  MdNotes,
   MdOutlineOndemandVideo,
   MdOutlineSwipeLeft,
 } from "react-icons/md";
@@ -119,15 +120,32 @@ export function findClassificationDescriptionIndex({
 export function compileActivityFromContent(activity: Content): ActivitySource {
   switch (activity.type) {
     case "singleDoc": {
-      return {
+      const documentJson = {
         id: activity.contentId,
         type: activity.type,
         title: activity.name,
-        isDescription: false,
+        isDescription: activity.isDescription ?? false,
         doenetML: activity.doenetML,
         version: activity.doenetmlVersion.fullVersion,
         numVariants: activity.numVariants,
       };
+      if (activity.repeatInProblemSet && activity.repeatInProblemSet > 1) {
+        // If the document repeats, wrap this document in
+        // a `select` which can select that many variants.
+        // Must stay in sync with the server compiler in
+        // `apps/api/src/utils/contentStructure.ts`, since the two produce the
+        // source for different views of the same problem set.
+        return {
+          id: `select_for_${activity.contentId}`,
+          type: "select",
+          title: `Repeat ${activity.repeatInProblemSet} times`,
+          numToSelect: activity.repeatInProblemSet,
+          selectByVariant: true,
+          items: [documentJson],
+        };
+      } else {
+        return documentJson;
+      }
     }
     case "select": {
       return {
@@ -184,12 +202,22 @@ export function getAllowedParentTypes(childTypes: ContentType[]) {
   return allowedParentTypes.reverse();
 }
 
-export function getIconInfo(contentType: ContentType, isAssignment: boolean) {
+export function getIconInfo(
+  contentType: ContentType,
+  isAssignment: boolean,
+  /** A document marked as a description: shown to students, but not scored. */
+  isDescription = false,
+) {
   let iconImage: IconType;
   let iconColor: string;
   if (isAssignment) {
     iconImage = IoStatsChart;
     iconColor = "blue";
+  } else if (isDescription) {
+    // Distinct shape as well as color, so the difference does not rely on
+    // color alone.
+    iconImage = MdNotes;
+    iconColor = "#6b7c93";
   } else if (contentType === "folder") {
     iconImage = FaFolder;
     iconColor = "#e6b800";

--- a/apps/app/src/views/CompoundActivityEditor.tsx
+++ b/apps/app/src/views/CompoundActivityEditor.tsx
@@ -281,6 +281,25 @@ export function CompoundActivityEditor({
             { method: "post", encType: "application/json" },
           );
         },
+        // Only documents directly inside a problem set can be descriptions.
+        isDescription:
+          content.type === "singleDoc" && content.parent?.type === "sequence"
+            ? (content.isDescription ?? false)
+            : undefined,
+        // Changing this renumbers the items, so the server rejects it once
+        // the content is assigned.
+        updateIsDescription: readOnly
+          ? undefined
+          : (isDescription) => {
+              fetcher.submit(
+                {
+                  path: "updateContent/updateContentSettings",
+                  contentId: content.contentId,
+                  isDescription,
+                },
+                { method: "post", encType: "application/json" },
+              );
+            },
       });
     }
 

--- a/apps/app/src/views/CompoundActivityEditor.tsx
+++ b/apps/app/src/views/CompoundActivityEditor.tsx
@@ -274,24 +274,27 @@ export function CompoundActivityEditor({
         indentLevel,
         // Repeating and describing are both settings of a document directly
         // inside a problem set; neither applies within a question bank.
+        // Both change the number of items, so the server rejects either one
+        // once the content is assigned; omitting the updater renders the
+        // control as disabled.
         repeatInProblemSet: inProblemSet
           ? content.repeatInProblemSet
           : undefined,
-        updateRepeatInProblemSet: (copies) => {
-          fetcher.submit(
-            {
-              path: "updateContent/updateContentSettings",
-              contentId: content.contentId,
-              repeatInProblemSet: copies,
+        updateRepeatInProblemSet: readOnly
+          ? undefined
+          : (copies) => {
+              fetcher.submit(
+                {
+                  path: "updateContent/updateContentSettings",
+                  contentId: content.contentId,
+                  repeatInProblemSet: copies,
+                },
+                { method: "post", encType: "application/json" },
+              );
             },
-            { method: "post", encType: "application/json" },
-          );
-        },
         isDescription: inProblemSet
           ? (content.isDescription ?? false)
           : undefined,
-        // Changing this renumbers the items, so the server rejects it once
-        // the content is assigned.
         updateIsDescription: readOnly
           ? undefined
           : (isDescription) => {

--- a/apps/app/src/views/CompoundActivityEditor.tsx
+++ b/apps/app/src/views/CompoundActivityEditor.tsx
@@ -258,6 +258,9 @@ export function CompoundActivityEditor({
   ) {
     const cards: CardContent[] = [];
 
+    const inProblemSet =
+      content.type === "singleDoc" && content.parent?.type === "sequence";
+
     // skip the first activity, which doesn't have parent info
     if (parentInfo) {
       cards.push({
@@ -269,8 +272,11 @@ export function CompoundActivityEditor({
               : editorUrl(content.contentId, content.type)
             : undefined,
         indentLevel,
-        repeatInProblemSet:
-          content.type === "singleDoc" ? content.repeatInProblemSet : undefined,
+        // Repeating and describing are both settings of a document directly
+        // inside a problem set; neither applies within a question bank.
+        repeatInProblemSet: inProblemSet
+          ? content.repeatInProblemSet
+          : undefined,
         updateRepeatInProblemSet: (copies) => {
           fetcher.submit(
             {
@@ -281,11 +287,9 @@ export function CompoundActivityEditor({
             { method: "post", encType: "application/json" },
           );
         },
-        // Only documents directly inside a problem set can be descriptions.
-        isDescription:
-          content.type === "singleDoc" && content.parent?.type === "sequence"
-            ? (content.isDescription ?? false)
-            : undefined,
+        isDescription: inProblemSet
+          ? (content.isDescription ?? false)
+          : undefined,
         // Changing this renumbers the items, so the server rejects it once
         // the content is assigned.
         updateIsDescription: readOnly

--- a/apps/app/src/views/CompoundActivityEditor.tsx
+++ b/apps/app/src/views/CompoundActivityEditor.tsx
@@ -25,6 +25,7 @@ import {
   Link as ReactRouterLink,
   useOutletContext,
   useNavigate,
+  useFetcher,
 } from "react-router";
 import { MoveCopyContent } from "../popups/MoveCopyContent";
 import CardList from "../widgets/CardList";
@@ -81,6 +82,12 @@ export function CompoundActivityEditor({
   deleteContentFetcher: FetcherWithComponents<any>;
 }) {
   const contentTypeName = contentTypeToName[activity.type];
+
+  // Per-document settings get their own fetcher. `fetcher` is shared with the
+  // popups, and `CopyContentAndReportFinish` treats any 200 on it as its own
+  // copy result — a settings save landing there leaves it with no
+  // `newContentIds` to render.
+  const settingsFetcher = useFetcher();
 
   const isAssigned = activity.assignmentInfo
     ? activity.assignmentInfo.assignmentStatus !== "Unassigned"
@@ -283,7 +290,7 @@ export function CompoundActivityEditor({
         updateRepeatInProblemSet: readOnly
           ? undefined
           : (copies) => {
-              fetcher.submit(
+              settingsFetcher.submit(
                 {
                   path: "updateContent/updateContentSettings",
                   contentId: content.contentId,
@@ -298,7 +305,7 @@ export function CompoundActivityEditor({
         updateIsDescription: readOnly
           ? undefined
           : (isDescription) => {
-              fetcher.submit(
+              settingsFetcher.submit(
                 {
                   path: "updateContent/updateContentSettings",
                   contentId: content.contentId,

--- a/apps/app/src/widgets/Card.cy.tsx
+++ b/apps/app/src/widgets/Card.cy.tsx
@@ -1,0 +1,81 @@
+import Card, { CardContent } from "./Card";
+import { Content } from "../types";
+
+const outletContext = {
+  user: undefined,
+  setAddTo: () => {},
+  allLicenses: [],
+};
+
+function docContent(overrides: Partial<Content> = {}): Content {
+  return {
+    contentId: "doc1",
+    name: "A document",
+    type: "singleDoc",
+    isPublic: false,
+    isShared: false,
+    visibility: "private",
+    licenseCode: null,
+    categories: [],
+    numVariants: 1,
+    ...overrides,
+  } as unknown as Content;
+}
+
+function mountCard(cardContent: Partial<CardContent>) {
+  cy.mount(
+    <Card
+      cardContent={{ content: docContent(), ...cardContent } as CardContent}
+    />,
+    { outletContext },
+  );
+}
+
+describe("Card description toggle", { tags: ["@group4"] }, () => {
+  it("is absent unless the document is inside a problem set", () => {
+    mountCard({});
+    cy.get('input[type="checkbox"][aria-label^="Description"]').should(
+      "not.exist",
+    );
+  });
+
+  it("reports a check to the update callback", () => {
+    const updateIsDescription = cy.stub().as("updateIsDescription");
+    mountCard({ isDescription: false, updateIsDescription });
+
+    cy.get('input[type="checkbox"][aria-label^="Description"]')
+      .should("not.be.checked")
+      .should("be.enabled");
+    // Chakra visually hides the input behind its own control, so click the label
+    cy.contains("label", "Description").click();
+    cy.get("@updateIsDescription").should("have.been.calledWith", true);
+  });
+
+  it("reports an uncheck to the update callback", () => {
+    const updateIsDescription = cy.stub().as("updateIsDescription");
+    mountCard({ isDescription: true, updateIsDescription });
+
+    cy.get('input[type="checkbox"][aria-label^="Description"]').should(
+      "be.checked",
+    );
+    cy.contains("label", "Description").click();
+    cy.get("@updateIsDescription").should("have.been.calledWith", false);
+  });
+
+  // Assigned (and otherwise read-only) content supplies no updater: changing
+  // the flag would renumber the items, so the server rejects it.
+  it("is disabled, but still shows its state, without an update callback", () => {
+    mountCard({ isDescription: true });
+
+    cy.get('input[type="checkbox"][aria-label^="Description"]')
+      .should("be.checked")
+      .should("be.disabled");
+  });
+
+  it("marks a description with its own icon and accessible name", () => {
+    mountCard({ isDescription: true, updateIsDescription: () => {} });
+
+    cy.get('[aria-label="Description (not scored)"]').should("exist");
+    cy.checkAccessibility("body");
+  });
+});

--- a/apps/app/src/widgets/Card.cy.tsx
+++ b/apps/app/src/widgets/Card.cy.tsx
@@ -79,3 +79,58 @@ describe("Card description toggle", { tags: ["@group4"] }, () => {
     cy.checkAccessibility("body");
   });
 });
+
+describe("Card repeat control", { tags: ["@group4"] }, () => {
+  function mountRepeatCard(cardContent: Partial<CardContent>) {
+    cy.mount(
+      <Card
+        cardContent={
+          {
+            content: docContent({ numVariants: 5 }),
+            ...cardContent,
+          } as CardContent
+        }
+      />,
+      { outletContext },
+    );
+  }
+
+  it("is absent unless the document is inside a problem set", () => {
+    mountRepeatCard({});
+    cy.get('input[aria-label^="Number of times to repeat"]').should(
+      "not.exist",
+    );
+  });
+
+  it("is absent for a description, which is never repeated", () => {
+    mountRepeatCard({
+      repeatInProblemSet: 3,
+      isDescription: true,
+      updateRepeatInProblemSet: () => {},
+    });
+    cy.get('input[aria-label^="Number of times to repeat"]').should(
+      "not.exist",
+    );
+  });
+
+  // Assigned (and otherwise read-only) content supplies no updater: changing
+  // the repeat would renumber the items, so the server rejects it.
+  it("is disabled, but still shows its value, without an update callback", () => {
+    mountRepeatCard({ repeatInProblemSet: 3 });
+
+    cy.get('input[aria-label^="Number of times to repeat"]')
+      .should("have.value", "3")
+      .should("be.disabled");
+  });
+
+  it("reports a new value to the update callback", () => {
+    const updateRepeatInProblemSet = cy.stub().as("updateRepeat");
+    mountRepeatCard({ repeatInProblemSet: 3, updateRepeatInProblemSet });
+
+    cy.get('input[aria-label^="Number of times to repeat"]')
+      .should("be.enabled")
+      .clear()
+      .type("2{enter}");
+    cy.get("@updateRepeat").should("have.been.calledWith", 2);
+  });
+});

--- a/apps/app/src/widgets/Card.tsx
+++ b/apps/app/src/widgets/Card.tsx
@@ -434,8 +434,10 @@ export default function Card({
   // The explanation also rides on `aria-label`, so it is not tooltip-only.
   const repeatExplanation =
     "Include this problem in the problem set more than once, each copy using a different variant of the document. Offered only for documents that have more than one variant.";
+  // A description is not a scored item, so it is never repeated.
   const repeatInProblemSet = cardContent.repeatInProblemSet &&
-    numVariants > 1 && (
+    numVariants > 1 &&
+    !cardContent.isDescription && (
       <HoverFocusTooltip label={repeatExplanation}>
         <HStack>
           <Text>Repeat:</Text>

--- a/apps/app/src/widgets/Card.tsx
+++ b/apps/app/src/widgets/Card.tsx
@@ -101,8 +101,9 @@ export type CardContent = {
   libraryEditorAvatarName?: string;
   repeatInProblemSet?: number;
   updateRepeatInProblemSet?: (copies: number) => void;
-  // Defined only for a document inside a problem set; `updateIsDescription` is
-  // omitted when the content cannot be changed (e.g. it is assigned).
+  // Defined only for a document inside a problem set; the matching updater is
+  // omitted when the content cannot be changed (e.g. it is assigned), which
+  // renders the control as disabled.
   isDescription?: boolean;
   updateIsDescription?: (isDescription: boolean) => void;
 };
@@ -447,18 +448,23 @@ export default function Card({
             min={1}
             max={numVariants}
             value={copyNum}
+            isDisabled={cardContent.updateRepeatInProblemSet === undefined}
             onChange={(valueString) => setCopyNum(parseInt(valueString))}
             onKeyDown={(e) => {
               if (e.key == "Enter") {
                 const target = e.target as HTMLInputElement;
                 if (parseInt(target.value) >= 1) {
-                  cardContent.updateRepeatInProblemSet!(parseInt(target.value));
+                  cardContent.updateRepeatInProblemSet?.(
+                    parseInt(target.value),
+                  );
                 }
               }
             }}
             onBlur={(e) => {
               if (parseInt(e.target.value) >= 1) {
-                cardContent.updateRepeatInProblemSet!(parseInt(e.target.value));
+                cardContent.updateRepeatInProblemSet?.(
+                  parseInt(e.target.value),
+                );
               }
             }}
           >

--- a/apps/app/src/widgets/Card.tsx
+++ b/apps/app/src/widgets/Card.tsx
@@ -54,6 +54,10 @@ export type CardContent = {
   libraryEditorAvatarName?: string;
   repeatInProblemSet?: number;
   updateRepeatInProblemSet?: (copies: number) => void;
+  // Defined only for a document inside a problem set; `updateIsDescription` is
+  // omitted when the content cannot be changed (e.g. it is assigned).
+  isDescription?: boolean;
+  updateIsDescription?: (isDescription: boolean) => void;
 };
 
 export default function Card({
@@ -148,17 +152,30 @@ export default function Card({
     ></Checkbox>
   );
 
-  // Content type icon
+  const descriptionExplanation =
+    "Shown to students but not numbered or scored. Do not put anything a student answers in a description — their work there is not saved or graded.";
+
+  // Content type icon. A description gets its own icon and color so that it
+  // reads as structurally different from the scored problems around it.
   const { iconImage, iconColor } = getIconInfo(
     contentType,
     Boolean(cardContent.content.assignmentInfo),
+    cardContent.isDescription,
   );
+  const contentTypeLabel = cardContent.content.assignmentInfo
+    ? "Assignment"
+    : cardContent.isDescription
+      ? "Description (not scored)"
+      : contentTypeName;
   const contentTypeIcon = (
     <Tooltip
       openDelay={500}
       label={
-        cardContent.content.assignmentInfo ? "Assignment" : contentTypeName
+        cardContent.isDescription
+          ? `Description: ${descriptionExplanation}`
+          : contentTypeLabel
       }
+      maxWidth="18rem"
     >
       <Flex
         alignItems="center"
@@ -170,9 +187,7 @@ export default function Card({
           color={iconColor}
           width={contentTypeIconSize}
           height={contentTypeIconSize}
-          aria-label={
-            cardContent.content.assignmentInfo ? "Assignment" : contentTypeName
-          }
+          aria-label={contentTypeLabel}
         />
       </Flex>
     </Tooltip>
@@ -366,40 +381,118 @@ export default function Card({
   );
 
   const [copyNum, setCopyNum] = useState(cardContent.repeatInProblemSet);
+  const [descriptionTipOpen, setDescriptionTipOpen] = useState(false);
+  const [repeatTipOpen, setRepeatTipOpen] = useState(false);
 
+  // Repeating compiles the document into a select that draws that many of its
+  // variants, so the student gets that many differing copies of the problem.
+  // Like the description toggle, the explanation rides on `aria-label` so it
+  // is not tooltip-only, and the tooltip is controlled so keyboard focus
+  // opens it too.
+  const repeatExplanation =
+    "Include this problem in the problem set more than once, each copy using a different variant of the document. Offered only for documents that have more than one variant.";
   const repeatInProblemSet = cardContent.repeatInProblemSet &&
     numVariants > 1 && (
-      <HStack>
-        <Text>Repeat:</Text>
-        <NumberInput
-          size="sm"
-          maxWidth="20"
-          min={1}
-          max={numVariants}
-          value={copyNum}
-          onChange={(valueString) => setCopyNum(parseInt(valueString))}
-          onKeyDown={(e) => {
-            if (e.key == "Enter") {
-              const target = e.target as HTMLInputElement;
-              if (parseInt(target.value) >= 1) {
-                cardContent.updateRepeatInProblemSet!(parseInt(target.value));
+      <Tooltip
+        isOpen={repeatTipOpen}
+        label={repeatExplanation}
+        maxWidth="18rem"
+        placement="bottom-end"
+        modifiers={[
+          {
+            name: "preventOverflow",
+            options: { boundary: "clippingParents", padding: 8 },
+          },
+        ]}
+      >
+        <HStack
+          onMouseEnter={() => setRepeatTipOpen(true)}
+          onMouseLeave={() => setRepeatTipOpen(false)}
+          onFocus={() => setRepeatTipOpen(true)}
+          onBlur={() => setRepeatTipOpen(false)}
+        >
+          <Text>Repeat:</Text>
+          <NumberInput
+            size="sm"
+            maxWidth="20"
+            min={1}
+            max={numVariants}
+            value={copyNum}
+            onChange={(valueString) => setCopyNum(parseInt(valueString))}
+            onKeyDown={(e) => {
+              if (e.key == "Enter") {
+                const target = e.target as HTMLInputElement;
+                if (parseInt(target.value) >= 1) {
+                  cardContent.updateRepeatInProblemSet!(parseInt(target.value));
+                }
               }
-            }
-          }}
-          onBlur={(e) => {
-            if (parseInt(e.target.value) >= 1) {
-              cardContent.updateRepeatInProblemSet!(parseInt(e.target.value));
-            }
+            }}
+            onBlur={(e) => {
+              if (parseInt(e.target.value) >= 1) {
+                cardContent.updateRepeatInProblemSet!(parseInt(e.target.value));
+              }
+            }}
+          >
+            <NumberInputField
+              aria-label={`Number of times to repeat this problem: ${repeatExplanation}`}
+            />
+            <NumberInputStepper>
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
+            </NumberInputStepper>
+          </NumberInput>
+        </HStack>
+      </Tooltip>
+    );
+
+  // A description is shown to students like any other document but is not one
+  // of the scored problems, so it gets no number and no credit. The warning
+  // rides on `aria-label` rather than only on the tooltip, so a screen reader
+  // announces it when the checkbox takes focus.
+  //
+  // The tooltip is controlled: Chakra binds its own focus handlers to the
+  // Checkbox's label wrapper, but focus lands on the inner input, so an
+  // uncontrolled tooltip never opens for a keyboard user. React's synthetic
+  // onFocus/onBlur bubble, so driving it from the wrapper covers both.
+  const isDescriptionToggle = cardContent.isDescription !== undefined && (
+    <Tooltip
+      isOpen={descriptionTipOpen}
+      label={descriptionExplanation}
+      maxWidth="18rem"
+      // The control sits at the right edge of the card, so anchor the
+      // tooltip's right edge to it and keep it inside the viewport —
+      // otherwise it hangs off the page and adds scrollbars.
+      placement="bottom-end"
+      modifiers={[
+        {
+          name: "preventOverflow",
+          options: { boundary: "clippingParents", padding: 8 },
+        },
+      ]}
+    >
+      <Flex
+        alignItems="center"
+        onMouseEnter={() => setDescriptionTipOpen(true)}
+        onMouseLeave={() => setDescriptionTipOpen(false)}
+        onFocus={() => setDescriptionTipOpen(true)}
+        onBlur={() => setDescriptionTipOpen(false)}
+      >
+        <Checkbox
+          size="sm"
+          isChecked={cardContent.isDescription}
+          isDisabled={cardContent.updateIsDescription === undefined}
+          aria-label={`Description: ${descriptionExplanation}`}
+          onChange={(e) => {
+            cardContent.updateIsDescription?.(e.target.checked);
           }}
         >
-          <NumberInputField />
-          <NumberInputStepper>
-            <NumberIncrementStepper />
-            <NumberDecrementStepper />
-          </NumberInputStepper>
-        </NumberInput>
-      </HStack>
-    );
+          <Text fontSize="sm" whiteSpace="nowrap">
+            Description
+          </Text>
+        </Checkbox>
+      </Flex>
+    </Tooltip>
+  );
 
   const menuMarginLeft = ["0em", "3em"];
   const menuDisplay = cardContent.inlineActions ? (
@@ -487,8 +580,16 @@ export default function Card({
               {addMenu}
             </Flex>
           )}
-          {/* Right-aligned, not main link */}
-          {repeatInProblemSet}
+          {/* Right-aligned, not main link. Repeat comes first: the description
+              toggle is on every document, so keeping it last lines it up in a
+              single column whether or not the optional repeat control is
+              present. */}
+          {(isDescriptionToggle || repeatInProblemSet) && (
+            <HStack spacing="0.75rem" paddingLeft="0.75rem">
+              {repeatInProblemSet}
+              {isDescriptionToggle}
+            </HStack>
+          )}
           {menuDisplay}
         </Flex>
       </CardBody>

--- a/apps/app/src/widgets/Card.tsx
+++ b/apps/app/src/widgets/Card.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from "react";
+import { ReactElement, ReactNode, useState } from "react";
 import {
   Text,
   Card as ChakraCard,
@@ -36,6 +36,53 @@ import { SmallLicenseBadges } from "./Licenses";
 import { IoDiceOutline } from "react-icons/io5";
 import { SiteContext } from "../paths/SiteHeader";
 import { AccessibleAvatar } from "./AccessibleAvatar";
+
+/**
+ * A tooltip that opens on keyboard focus as well as on hover.
+ *
+ * Chakra binds its own handlers to the outermost element of the tooltip's child,
+ * which for a form control is a label wrapper that never takes focus itself, so
+ * an uncontrolled tooltip never opens for a keyboard user. React's synthetic
+ * focus events bubble, so driving a controlled tooltip from a wrapper covers
+ * both pointer and keyboard.
+ */
+function HoverFocusTooltip({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Tooltip
+      isOpen={isOpen}
+      label={label}
+      maxWidth="18rem"
+      // These controls sit at the right edge of the card, so anchor the
+      // tooltip's right edge to them and keep it inside the viewport —
+      // otherwise it hangs off the page and adds scrollbars.
+      placement="bottom-end"
+      modifiers={[
+        {
+          name: "preventOverflow",
+          options: { boundary: "clippingParents", padding: 8 },
+        },
+      ]}
+    >
+      <Flex
+        alignItems="center"
+        onMouseEnter={() => setIsOpen(true)}
+        onMouseLeave={() => setIsOpen(false)}
+        onFocus={() => setIsOpen(true)}
+        onBlur={() => setIsOpen(false)}
+      >
+        {children}
+      </Flex>
+    </Tooltip>
+  );
+}
 
 export type CardContent = {
   menuRef?: (arg: HTMLButtonElement) => void;
@@ -381,36 +428,16 @@ export default function Card({
   );
 
   const [copyNum, setCopyNum] = useState(cardContent.repeatInProblemSet);
-  const [descriptionTipOpen, setDescriptionTipOpen] = useState(false);
-  const [repeatTipOpen, setRepeatTipOpen] = useState(false);
 
   // Repeating compiles the document into a select that draws that many of its
   // variants, so the student gets that many differing copies of the problem.
-  // Like the description toggle, the explanation rides on `aria-label` so it
-  // is not tooltip-only, and the tooltip is controlled so keyboard focus
-  // opens it too.
+  // The explanation also rides on `aria-label`, so it is not tooltip-only.
   const repeatExplanation =
     "Include this problem in the problem set more than once, each copy using a different variant of the document. Offered only for documents that have more than one variant.";
   const repeatInProblemSet = cardContent.repeatInProblemSet &&
     numVariants > 1 && (
-      <Tooltip
-        isOpen={repeatTipOpen}
-        label={repeatExplanation}
-        maxWidth="18rem"
-        placement="bottom-end"
-        modifiers={[
-          {
-            name: "preventOverflow",
-            options: { boundary: "clippingParents", padding: 8 },
-          },
-        ]}
-      >
-        <HStack
-          onMouseEnter={() => setRepeatTipOpen(true)}
-          onMouseLeave={() => setRepeatTipOpen(false)}
-          onFocus={() => setRepeatTipOpen(true)}
-          onBlur={() => setRepeatTipOpen(false)}
-        >
+      <HoverFocusTooltip label={repeatExplanation}>
+        <HStack>
           <Text>Repeat:</Text>
           <NumberInput
             size="sm"
@@ -442,56 +469,29 @@ export default function Card({
             </NumberInputStepper>
           </NumberInput>
         </HStack>
-      </Tooltip>
+      </HoverFocusTooltip>
     );
 
   // A description is shown to students like any other document but is not one
   // of the scored problems, so it gets no number and no credit. The warning
-  // rides on `aria-label` rather than only on the tooltip, so a screen reader
-  // announces it when the checkbox takes focus.
-  //
-  // The tooltip is controlled: Chakra binds its own focus handlers to the
-  // Checkbox's label wrapper, but focus lands on the inner input, so an
-  // uncontrolled tooltip never opens for a keyboard user. React's synthetic
-  // onFocus/onBlur bubble, so driving it from the wrapper covers both.
+  // also rides on `aria-label`, so a screen reader announces it when the
+  // checkbox takes focus.
   const isDescriptionToggle = cardContent.isDescription !== undefined && (
-    <Tooltip
-      isOpen={descriptionTipOpen}
-      label={descriptionExplanation}
-      maxWidth="18rem"
-      // The control sits at the right edge of the card, so anchor the
-      // tooltip's right edge to it and keep it inside the viewport —
-      // otherwise it hangs off the page and adds scrollbars.
-      placement="bottom-end"
-      modifiers={[
-        {
-          name: "preventOverflow",
-          options: { boundary: "clippingParents", padding: 8 },
-        },
-      ]}
-    >
-      <Flex
-        alignItems="center"
-        onMouseEnter={() => setDescriptionTipOpen(true)}
-        onMouseLeave={() => setDescriptionTipOpen(false)}
-        onFocus={() => setDescriptionTipOpen(true)}
-        onBlur={() => setDescriptionTipOpen(false)}
+    <HoverFocusTooltip label={descriptionExplanation}>
+      <Checkbox
+        size="sm"
+        isChecked={cardContent.isDescription}
+        isDisabled={cardContent.updateIsDescription === undefined}
+        aria-label={`Description: ${descriptionExplanation}`}
+        onChange={(e) => {
+          cardContent.updateIsDescription?.(e.target.checked);
+        }}
       >
-        <Checkbox
-          size="sm"
-          isChecked={cardContent.isDescription}
-          isDisabled={cardContent.updateIsDescription === undefined}
-          aria-label={`Description: ${descriptionExplanation}`}
-          onChange={(e) => {
-            cardContent.updateIsDescription?.(e.target.checked);
-          }}
-        >
-          <Text fontSize="sm" whiteSpace="nowrap">
-            Description
-          </Text>
-        </Checkbox>
-      </Flex>
-    </Tooltip>
+        <Text fontSize="sm" whiteSpace="nowrap">
+          Description
+        </Text>
+      </Checkbox>
+    </HoverFocusTooltip>
   );
 
   const menuMarginLeft = ["0em", "3em"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,7 @@
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.10.9",
         "@doenet-tools/shared": "*",
-        "@doenet/assignment-viewer": "^0.1.0-alpha-17",
+        "@doenet/assignment-viewer": "^0.1.0-alpha-18",
         "@doenet/doenetml-iframe": "^0.7.24",
         "@doenet/v06-to-v07": "^0.7.24",
         "@fontsource/jost": "^5.2.6",
@@ -2427,9 +2427,9 @@
       "link": true
     },
     "node_modules/@doenet/assignment-viewer": {
-      "version": "0.1.0-alpha-17",
-      "resolved": "https://registry.npmjs.org/@doenet/assignment-viewer/-/assignment-viewer-0.1.0-alpha-17.tgz",
-      "integrity": "sha512-DRMfmmAY4lzLuM0OlQURA3n8qqEE0HdP+ecJCTqDNGCDfUNO059twUVigqkB8jGXshrdXXY6hRuy8BlzaTgplg==",
+      "version": "0.1.0-alpha-18",
+      "resolved": "https://registry.npmjs.org/@doenet/assignment-viewer/-/assignment-viewer-0.1.0-alpha-18.tgz",
+      "integrity": "sha512-BTj2E34a6pNXHHnr5hbPu4JLXpD4iHLLQ4Y2CDjPfchr0sf3rOMEsgttYf0AggJBOPSrw0exWZCcfrlldSR1rQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "nanoid": "^5.1.6",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,4 @@ export * from "./apiTypes.js";
 export * from "./logic/browsable.js";
 export * from "./logic/categoryRules.js";
 export * from "./logic/mediaLicense.js";
+export * from "./logic/problemSetItems.js";

--- a/packages/shared/src/logic/problemSetItems.test.ts
+++ b/packages/shared/src/logic/problemSetItems.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { repeatCountInProblemSet } from "./problemSetItems.js";
+
+describe("repeatCountInProblemSet", () => {
+  test("a document with no settings appears once", () => {
+    expect(repeatCountInProblemSet({})).eqls(1);
+    expect(repeatCountInProblemSet({ numVariants: 5 })).eqls(1);
+  });
+
+  test("a repeated document appears that many times", () => {
+    expect(
+      repeatCountInProblemSet({ repeatInProblemSet: 3, numVariants: 5 }),
+    ).eqls(3);
+  });
+
+  test("the repeat is capped by the number of variants", () => {
+    expect(
+      repeatCountInProblemSet({ repeatInProblemSet: 3, numVariants: 2 }),
+    ).eqls(2);
+    expect(
+      repeatCountInProblemSet({ repeatInProblemSet: 3, numVariants: 1 }),
+    ).eqls(1);
+  });
+
+  test("the repeat is at least one", () => {
+    expect(
+      repeatCountInProblemSet({ repeatInProblemSet: 0, numVariants: 5 }),
+    ).eqls(1);
+  });
+
+  test("a description is never repeated", () => {
+    expect(
+      repeatCountInProblemSet({
+        isDescription: true,
+        repeatInProblemSet: 3,
+        numVariants: 5,
+      }),
+    ).eqls(1);
+  });
+});

--- a/packages/shared/src/logic/problemSetItems.ts
+++ b/packages/shared/src/logic/problemSetItems.ts
@@ -1,0 +1,25 @@
+/**
+ * The number of copies of a document that a problem set contains.
+ *
+ * A description is not a scored item, so it is never repeated. Otherwise the
+ * document is repeated `repeatInProblemSet` times, capped by the number of
+ * variants it has: each copy uses a different variant, and `numVariants` can
+ * drop below a previously saved `repeatInProblemSet` (by editing the source or
+ * reverting the document to an earlier revision).
+ *
+ * Both activity compilers and the gradebook's item names go through this, so
+ * that the item count derived for the gradebook matches the compiled activity.
+ */
+export function repeatCountInProblemSet(doc: {
+  isDescription?: boolean;
+  repeatInProblemSet?: number;
+  numVariants?: number;
+}) {
+  if (doc.isDescription) {
+    return 1;
+  }
+  return Math.max(
+    1,
+    Math.min(doc.repeatInProblemSet ?? 1, doc.numVariants ?? 1),
+  );
+}


### PR DESCRIPTION
> **Dependency:** bumped to `@doenet/assignment-viewer@0.1.0-alpha-18` (Doenet/assignment-viewer#49), which is published. That release fixes the item indexing descriptions depend on: it separates the document sequence from the scored-item sequence, so `doenetStates`, `itemAttemptNumbers`, and the reported `item_updated` are all keyed by scored item — which is what this app stores per-item state by. The full suite has been re-run against the published package.

## Before deploying

Two manual steps, both of which will bite on prod if skipped. Full procedure, with the pre-flight results already gathered from prod, is in [`MANUAL_MIGRATION_PLAN.md`](./MANUAL_MIGRATION_PLAN.md).

**1. Apply the migration out-of-band, before the image.** `ADD COLUMN` on `content` cannot use instant DDL — its two FULLTEXT indexes force a full `ALGORITHM=COPY` rebuild, measured at **7 min 3 s on dev3** against a **5-minute deploy timeout**. The deploy kills it mid-rebuild, and because MySQL DDL is not transactional the column commits while Prisma's bookkeeping does not, leaving `_prisma_migrations` unfinished. Every subsequent deploy then fails with `P3009` — **including a rollback to `main`** — until someone runs `prisma migrate resolve` by hand. This already happened on dev3 (2026-08-15 02:30 UTC). Prod's `content` is larger, so expect longer, with **writes blocked for the duration**. Apply the migration on its own first, mark it applied, then deploy the image. Tracked in #3027.

**2. Check for repeats on live assignments.** `SELECT COUNT(*) FROM content WHERE repeatInProblemSet > 1` — a problem set assigned *before* this deploy with a repeated document gains items on the next student load, and its gradebook columns shift with them. Reviewed on prod 2026-08-17: of 15, six are soft-deleted and three sit in assigned problem sets, all experimental — no reset needed. Re-check before deploying if time has passed. See the behavior-change note below.

## Descriptions

A problem set had no way to include an introduction, a section header, or shared setup text — every child document was a scored, numbered problem.

The viewer already had the concept: `SingleDocSource.isDescription` marks a document as unscored and unnumbered, and it was implemented for question numbering, credit, shuffle anchoring, and the per-item attempt button. Nothing here could set it — both compilers hardcoded `isDescription: false`.

This adds:

- `content.isDescription` column + migration (one line, matching `20250804195804_problem_set_repeat_doc`)
- the flag threaded through `returnContentSelect` → `processContent` → both compilers
- `isDescription` on `updateContentSettings`, with the same three gates as `repeatInProblemSet`: the all-undefined no-op, the `singleDoc` whose parent is a `sequence` check, and the assigned-content guard. It is on the **forbidden** list when assigned, because changing it renumbers the items and existing attempts' stored `itemNumber`s would no longer line up.
- `getItemNames` skips descriptions, so they take no gradebook column and no `itemNumber` in stored item state
- both compilers honor `isDescription` and `repeatInProblemSet` only for a document whose parent is a problem set, and never repeat a description. The viewer throws outright on a `select` whose items include a description (`"The case where a select contains a description is not implemented"`), and both states are reachable from stored data: `moveContent` carries the flag when a description is dragged into a question bank, and the Repeat and Description controls could otherwise both be set on one document. The editor also hides the Repeat control on a description.
- a **Description** checkbox on each document card in the problem set editor, disabled (but still showing its state) once the content is read-only, and a distinct icon (`MdNotes`, slate) so descriptions read as structurally different from the problems around them — shape *and* colour, not colour alone

Both the Description and Repeat controls now explain themselves. The text rides on `aria-label`, not only the tooltip, so it is announced on focus rather than being hover-only; the tooltips are controlled because Chakra binds its focus handlers to the Checkbox's label wrapper while focus lands on the inner input, so an uncontrolled tooltip never opens for a keyboard user. Both share one `HoverFocusTooltip` wrapper in `Card.tsx` that owns that behaviour and the overflow placement.

## Bugs this uncovered

**`repeatInProblemSet` was silently dropped almost everywhere.** It was selected only when a caller passed `includeRepeatInProblemSet: true`, and most did not — including `createContentRevision`, so it vanished from stored revision sources and their cids. Only the compound-editor preview ever saw it. Both problem-set document settings are now selected unconditionally and the flag is deleted. `isDescription` never went behind it: dropping it would shift item numbering between preview and assignment, which is exactly the corruption this PR exists to avoid.

**A repeat escaped the problem set.** Both settings live on the document row and travel with it — `moveContent` and `copyContent` carry the whole row — so a document repeated in a problem set keeps `repeatInProblemSet > 1` after being moved into a question bank. The server compiler's repeat branch was not scoped to a problem set, and once the field is selected unconditionally that compiles a `select` *inside* the bank, producing more items than the bank's `numToSelect` accounts for and than `getItemNames` labels. Both compilers now apply the repeat only to a direct child of a `sequence`, exactly as they do `isDescription`, and the editor offers the Repeat control only there (it always did the update call, which the server then rejected). The Repeat control is also disabled on read-only content, matching the Description checkbox — it was previously left editable on an assigned problem set, where every change failed with `Cannot change assigned content`.

**A repeat could outlive its variants.** The repeat is clamped to `numVariants` when it is set, but `numVariants` moves independently afterwards — editing the source down to fewer variants, or `revertToRevision`, which writes `numVariants` straight to the row. A stale `repeat = 3` on a now-2-variant document asked the viewer for three distinct variants of two, and the editor shows the Repeat control only for multi-variant documents, so a document that fell to one variant could not be corrected at all. Both compilers now cap the repeat at `numVariants` at compile time, and `getItemNames` uses the same cap so the gradebook columns still match. The rule lives once, in `packages/shared/src/logic/problemSetItems.ts` as `repeatCountInProblemSet` — it also folds in the description rule, and both compilers and `getItemNames` are its only callers, so the item count derived for the gradebook cannot drift from the compiled activity.

**Item names did not account for repeats.** `getItemNames` produces the gradebook column labels indexed by `itemNumber`, so it must line up one-to-one with the items of the compiled activity. It expanded a question bank into one name per selection but gave a repeated document a single name — harmless while repeats were being dropped, wrong the moment they compile. It now expands a repeat the same way (`Problem (1)`, `Problem (2)`), skips descriptions, and shares one `repeatedItemNames` helper across all three cases instead of three copies of the same loop. `getAssignmentResponseStudent` selects `repeatInProblemSet`, `isDescription`, and `numVariants` on its children so its own call site gets the same answer.

**Students never saw repeats at all**, regardless of data selection, because the client compiler had no repeat branch. It now wraps a repeated document in the same synthetic `select` the server builds, and the server now emits `title` on a document as the client already did — so every path compiles a problem set identically.

The `title` gap was closed on the *server* side deliberately: the server-compiled source only feeds revision cids, so no student's `sourceHash` changes. Removing `title` from the client instead would have invalidated saved state for every problem set.

> **Behavior change:** problem sets with `repeat > 1` now compile to more items than before, so existing attempts on such content will hash-mismatch and start fresh. `repeat = 1` — the default, and the overwhelming majority — compiles byte-identically and is unaffected.
>

> This reaches *already-assigned* problem sets too: assignments compile their source live, so a problem set assigned before this deploy with a repeated document gains items on the next student load, and its gradebook columns shift with them. The repeat is locked once assigned, so this only affects content whose repeat was set before it was assigned.

## Dead code removed

`activityJson` was declared on `QuestionBank` and `ProblemSet` and read by four loaders, but **the API never populated it** — every one of those loaders always took the `compileActivityFromContent` fallback. Git history shows why: it began as a client-side local, and a later PR added the "stored revision source" fallback shape and the type field without ever implementing the server half.

Deleted the field and collapsed the four fallbacks. Kept the loader result key of the same name (that is the real compiled source) and RawViewer's by-cid branch, which parses a genuinely stored revision source and whose `isActivitySource` guard is load-bearing.

## Editor crash fixed

`CompoundActivityEditor` shares one fetcher with its popups, and `CopyContentAndReportFinish` treats any 200 on it as its own copy result, reading `data.newContentIds`. A settings save landing there set `newContentIds` to `undefined`, which passes the `=== null` guard and crashed the render on `.length`.

The copy modal is mounted whenever `addTo !== null`, which "Items from Explore" sets *before* navigating — so clicking a document's Description checkbox during that window crashed the editor. Found on dev3, where the navigation is slow enough to leave the window open; it does not reproduce locally.

Both settings updates now use their own fetcher, so their responses never reach the popups, and the copy modal accepts only a response actually carrying an array `newContentIds` — a guard that covers all six of its call sites. `MoveCopyContent` shared the same assumption and the same latent crash — reporting the action finished on any 200, and crashing on the copy path reading `data.newContentIds.length`. It could not use the same guard, because `moveContent` returns no payload and so a move's success is indistinguishable from any other 200. It now tracks whether it started the submission: a ref armed immediately before each submit, consumed in the effect, cleared whenever the modal opens.

## Tests

- `npm test -w @doenet-tools/api` — 387 pass. New: `isDescription` update rules including that `false` is a real value rather than a no-op; a description compiling into the activity without being a scored item; a regression test that `repeatInProblemSet` survives into the compiled activity from a plain `getContent` call (verified adversarially — with the select removed it fails with `expected 'singleDoc' to deeply equal 'select'`); a description with a repeat compiling to a plain document rather than a select; a repeat capped at `numVariants` after the document is edited down (in the compiled source and in the item names); a repeated document moved into a question bank compiling to a plain document; and an assignment-level test that the item names of a problem set of description + repeated problem + question bank come out as `["Problem (1)", "Problem (2)", "Bank"]`.
- New `apps/app/src/utils/activity.cy.tsx` — 9 tests covering the client compiler: title and description flag, `isDescription` defaulting, the repeat wrapper's exact shape, that `repeat = 1` still compiles to a bare `singleDoc` so existing source hashes are preserved, that a description is not repeated, that `isDescription` and `repeatInProblemSet` are both ignored outside a problem set, and that the repeat is capped at (and dropped below) `numVariants`. The server-side assertions mirror these and each suite's comments point at the other, so the twin compilers cannot drift silently.
- New `apps/app/src/widgets/Card.cy.tsx` — 9 tests for the two problem-set controls. Description: absent unless the document is in a problem set, reports check and uncheck to the callback, disabled but still showing its state when there is no updater (assigned content), and the description icon's accessible name plus an axe pass. Repeat: absent outside a problem set, absent on a description, disabled but still showing its value without an updater, and reporting a new value to the callback.
- New `packages/shared/src/logic/problemSetItems.test.ts` — 5 tests pinning `repeatCountInProblemSet` directly: the default of one, the plain repeat, the `numVariants` cap in both directions, the floor of one, and a description never repeating.

Each fix was checked adversarially: reverting the `inProblemSet` gate, the `numVariants` cap, the description rule, or the item-name expansion each makes exactly the intended test (and only that test) fail.

## Verified end to end

Against a running dev stack, a problem set of description + one problem + one problem repeated 3× rendered:

```
Problem 1 | Problem 2 | Problem 3 | Problem 4   ::iframes=5
```

Five documents — the description (unnumbered) plus four numbered problems, with numbering continuing across the repeat. Before this, it was three documents and the repeat was dropped.

## Not covered

The assigned-student persistence round trip (answer, reload, confirm the answer restores into the right problem) and the gradebook column count were not exercised against a real assignment. The viewer's own tests pin the numbering and reporting these depend on.










