### PR TITLE
Remove the dead activityJson field

### DIFF
--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -225,7 +225,6 @@ export type Doc = ContentBase & {
 
 export type QuestionBank = ContentBase & {
   type: "select";
-  activityJson?: string;
   revisionNum?: number;
   numToSelect: number;
   selectByVariant: boolean;
@@ -234,7 +233,6 @@ export type QuestionBank = ContentBase & {
 
 export type ProblemSet = ContentBase & {
   type: "sequence";
-  activityJson?: string;
   revisionNum?: number;
   shuffle: boolean;
   paginate: boolean;

--- a/apps/app/src/paths/ActivityViewer.tsx
+++ b/apps/app/src/paths/ActivityViewer.tsx
@@ -66,7 +66,7 @@ import {
   getIconInfo,
   menuIcons,
 } from "../utils/activity";
-import { ActivitySource, isActivitySource } from "@doenet-tools/shared";
+import { ActivitySource } from "@doenet-tools/shared";
 import { DoenetEditor, DoenetViewer } from "@doenet/doenetml-iframe";
 import { doenetImagesUrl } from "../utils/media";
 import { ActivityViewer as DoenetActivityViewer } from "@doenet/assignment-viewer";
@@ -114,13 +114,7 @@ export async function loader({ params }: { params: any }) {
       libraryRelations,
     };
   } else {
-    const activityJsonFromRevision = activityData.activityJson
-      ? JSON.parse(activityData.activityJson)
-      : null;
-
-    const activityJson = isActivitySource(activityJsonFromRevision)
-      ? activityJsonFromRevision
-      : compileActivityFromContent(activityData);
+    const activityJson = compileActivityFromContent(activityData);
 
     return {
       type: activityData.type,

--- a/apps/app/src/paths/AssignmentResponseOverview.tsx
+++ b/apps/app/src/paths/AssignmentResponseOverview.tsx
@@ -45,7 +45,6 @@ import {
   DoenetmlVersion,
   UserInfoWithEmail,
 } from "../types";
-import { isActivitySource } from "@doenet/assignment-viewer";
 import {
   compileActivityFromContent,
   contentTypeToName,
@@ -173,13 +172,7 @@ export async function loader({ params, request }: ActionFunctionArgs) {
       doenetmlVersion,
     };
   } else if (assignment.type !== "folder" && assignment.type !== "image") {
-    const activityJsonPrelim = assignment.activityJson
-      ? JSON.parse(assignment.activityJson)
-      : null;
-
-    const activityJson = isActivitySource(activityJsonPrelim)
-      ? activityJsonPrelim
-      : compileActivityFromContent(assignment);
+    const activityJson = compileActivityFromContent(assignment);
 
     const itemNames = data.itemNames;
 

--- a/apps/app/src/paths/AssignmentViewer.tsx
+++ b/apps/app/src/paths/AssignmentViewer.tsx
@@ -17,11 +17,7 @@ import {
 } from "./EnterClassCode";
 import { SiteContext } from "./SiteHeader";
 import { Content, DoenetmlVersion } from "../types";
-import {
-  ActivitySource,
-  isActivitySource,
-  isReportStateMessage,
-} from "@doenet-tools/shared";
+import { ActivitySource, isReportStateMessage } from "@doenet-tools/shared";
 import { compileActivityFromContent } from "../utils/activity";
 import { ActivityViewer as DoenetActivityViewer } from "@doenet/assignment-viewer";
 import { effectiveDarkMode, useThemeSettingContext } from "../utils/theme";
@@ -188,13 +184,7 @@ export async function loader({ params }: { params: any }) {
       loadedScore,
     };
   } else {
-    const activityJsonPrelim = data.assignment.activityJson
-      ? JSON.parse(data.assignment.activityJson)
-      : null;
-
-    const activityJson = isActivitySource(activityJsonPrelim)
-      ? activityJsonPrelim
-      : compileActivityFromContent(data.assignment);
+    const activityJson = compileActivityFromContent(data.assignment);
 
     return {
       assignmentFound: true,

--- a/apps/app/src/paths/RawViewer.tsx
+++ b/apps/app/src/paths/RawViewer.tsx
@@ -35,13 +35,7 @@ export async function loader({ params }: any) {
         contentId,
       };
     } else {
-      const activityJsonFromRevision = activityData.activityJson
-        ? JSON.parse(activityData.activityJson)
-        : null;
-
-      const activityJson = isActivitySource(activityJsonFromRevision)
-        ? activityJsonFromRevision
-        : compileActivityFromContent(activityData);
+      const activityJson = compileActivityFromContent(activityData);
 
       return {
         type: activityData.type,

--- a/apps/app/src/types.ts
+++ b/apps/app/src/types.ts
@@ -194,7 +194,6 @@ export type Doc = ContentBase & {
 
 export type QuestionBank = ContentBase & {
   type: "select";
-  activityJson?: string;
   revisionNum?: number;
   numToSelect: number;
   selectByVariant: boolean;
@@ -203,7 +202,6 @@ export type QuestionBank = ContentBase & {
 
 export type ProblemSet = ContentBase & {
   type: "sequence";
-  activityJson?: string;
   revisionNum?: number;
   shuffle: boolean;
   paginate: boolean;


### PR DESCRIPTION
`activityJson` was declared on `QuestionBank` and `ProblemSet`, and four loaders read it. The API never populated it, so every one of those loaders always fell through to `compileActivityFromContent` instead.

It appears to have started life as a client-side local. A later PR added the "stored revision source" fallback shape and the type field alongside it, but the server half that would have filled it in was never written.

This removes the field and collapses the four fallbacks down to the call that was already doing the work.

Two things that look similar are kept deliberately:

- the loader result key of the same name — that one is the real compiled source
- `RawViewer`'s by-cid branch, which parses a genuinely stored revision source; its `isActivitySource` guard is load-bearing

No runtime change, since the deleted branch was unreachable. `tsc --noEmit` passes on `apps/api` and `apps/app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Takes code from #3026)