### PR TITLE
Only react to a fetcher result the popup actually asked for

### DIFF
--- a/apps/app/src/popups/CopyContentAndReportFinish.cy.tsx
+++ b/apps/app/src/popups/CopyContentAndReportFinish.cy.tsx
@@ -536,5 +536,35 @@ describe(
         cy.checkAccessibility("body");
       });
     });
+
+    // `fetcher` is shared with the rest of the editor. Saving a per-document
+    // setting (e.g. the Repeat control) while this modal is mounted puts
+    // a foreign 200 on it — one with no `newContentIds`. Treating that as the
+    // copy's own result used to crash the render with
+    // "Cannot read properties of undefined (reading 'length')".
+    it("ignores a 200 on the shared fetcher that is not its own result", () => {
+      const foreignResponse = createMockFetcher({
+        status: 200,
+        data: { contentId: "some-doc", repeatInProblemSet: 2 },
+      });
+
+      cy.mount(
+        <CopyContentAndReportFinish
+          isOpen={true}
+          onClose={cy.spy().as("onClose")}
+          contentIds={["content1"]}
+          desiredParent={mockParentSequence}
+          action="Add"
+          fetcher={foreignResponse}
+          user={mockUser}
+          setAddTo={cy.spy().as("setAddTo")}
+          onNavigate={cy.spy().as("onNavigate")}
+        />,
+      );
+
+      // still waiting on its own result rather than crashing or claiming success
+      cy.get('[data-test="Copy Header"]').should("have.text", "Adding");
+      cy.contains("item added to").should("not.exist");
+    });
   },
 );

--- a/apps/app/src/popups/CopyContentAndReportFinish.tsx
+++ b/apps/app/src/popups/CopyContentAndReportFinish.tsx
@@ -57,7 +57,13 @@ export function CopyContentAndReportFinish({
   useEffect(() => {
     if (fetcher.data) {
       if (fetcher.data.status === 200) {
-        setNewContentIds(fetcher.data.data.newContentIds);
+        // `fetcher` is shared with the rest of the editor, so a 200 here is not
+        // necessarily this copy's result. Only a response actually carrying
+        // `newContentIds` is ours; anything else is another submission's.
+        const ids = fetcher.data.data?.newContentIds;
+        if (Array.isArray(ids)) {
+          setNewContentIds(ids);
+        }
       } else {
         const message = fetcher.data.message;
         setErrMsg(

--- a/apps/app/src/popups/MoveCopyContent.cy.tsx
+++ b/apps/app/src/popups/MoveCopyContent.cy.tsx
@@ -633,4 +633,53 @@ describe("MoveCopyContent component tests", { tags: ["@group2"] }, () => {
       cy.checkAccessibility("body");
     });
   });
+
+  // `fetcher` is shared with the rest of the page, so a settings save or any
+  // other submission can land a 200 on it while this modal is mounted. A move
+  // returns no payload, so the response cannot be recognized — the modal must
+  // only react to a result it actually asked for. Reacting to a foreign one
+  // used to report a completed action, and crash on the Copy path reading
+  // `data.newContentIds.length` of undefined.
+  it("ignores a result on the shared fetcher that it did not ask for", () => {
+    cy.intercept("/api/copyMove/getMoveCopyContentData/*", {
+      parent: null,
+      contents: contentList1,
+    }).as("getData");
+
+    const foreignResult = {
+      state: "idle",
+      formData: undefined,
+      data: {
+        status: 200,
+        data: { contentId: "some-doc", repeatInProblemSet: 2 },
+      },
+      Form: ({ children }: any) => <form>{children}</form>,
+      submit: () => {},
+      load: () => {},
+    } as unknown as FetcherWithComponents<any>;
+
+    cy.mount(
+      <MoveCopyContent
+        isOpen={true}
+        onClose={cy.spy().as("onClose")}
+        onNavigate={cy.spy().as("onNavigate")}
+        fetcher={foreignResult}
+        sourceContent={[{ contentId, name: contentName, type: contentType }]}
+        userId={"abc123"}
+        currentParentId={null}
+        allowedParentTypes={["folder"]}
+        action="Copy"
+      />,
+    );
+
+    cy.wait("@getData");
+
+    // still offering the action rather than claiming it finished
+    cy.get('[data-test="Execute MoveCopy Button"]').should("be.visible");
+    cy.get('[data-test="Go to Destination"]').should("not.exist");
+    cy.get('[data-test="MoveCopy Body"]').should(
+      "not.contain.text",
+      "copied to",
+    );
+  });
 });

--- a/apps/app/src/popups/MoveCopyContent.tsx
+++ b/apps/app/src/popups/MoveCopyContent.tsx
@@ -106,6 +106,7 @@ export function MoveCopyContent({
     }
     setActionFinished(false);
     setErrMsg("");
+    awaitingOwnResult.current = false;
     // TODO: proper way to have functions and hooks
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, currentParentId]);
@@ -142,16 +143,23 @@ export function MoveCopyContent({
 
   const initialRef = useRef<HTMLButtonElement>(null);
 
+  // `fetcher` is shared with the rest of the page, so a response on it is not
+  // necessarily this modal's. A move returns no payload, so there is nothing in
+  // the response to recognize — track who started the submission instead.
+  const awaitingOwnResult = useRef(false);
+
   useEffect(() => {
-    if (fetcher.data && fetcher.data.status === 200) {
+    if (!fetcher.data || !awaitingOwnResult.current) {
+      return;
+    }
+    awaitingOwnResult.current = false;
+
+    if (fetcher.data.status === 200) {
       setActionFinished(true);
-      if (action === "Move") {
-        setNumItems(1);
-      } else {
-        const numItems: number = fetcher.data.data.newContentIds.length;
-        setNumItems(numItems);
-      }
-    } else if (fetcher.data && fetcher.data.success === false) {
+      setNumItems(
+        action === "Move" ? 1 : (fetcher.data.data?.newContentIds?.length ?? 0),
+      );
+    } else if (fetcher.data.success === false) {
       setErrMsg(fetcher.data.message);
     }
   }, [fetcher.data, action]);
@@ -456,6 +464,7 @@ export function MoveCopyContent({
 
     if (action === "Move") {
       if (contentIds.length === 1) {
+        awaitingOwnResult.current = true;
         fetcher.submit(
           {
             path: `copyMove/moveContent`,
@@ -469,6 +478,7 @@ export function MoveCopyContent({
         throw Error("Have not implemented moving more than one content");
       }
     } else if (action === "Copy" || action === "Add") {
+      awaitingOwnResult.current = true;
       fetcher.submit(
         {
           path: "copyMove/copyContent",

--- a/apps/app/src/views/CompoundActivityEditor.tsx
+++ b/apps/app/src/views/CompoundActivityEditor.tsx
@@ -25,6 +25,7 @@ import {
   Link as ReactRouterLink,
   useOutletContext,
   useNavigate,
+  useFetcher,
 } from "react-router";
 import { MoveCopyContent } from "../popups/MoveCopyContent";
 import CardList from "../widgets/CardList";
@@ -81,6 +82,12 @@ export function CompoundActivityEditor({
   deleteContentFetcher: FetcherWithComponents<any>;
 }) {
   const contentTypeName = contentTypeToName[activity.type];
+
+  // Per-document settings get their own fetcher. `fetcher` is shared with the
+  // popups, and `CopyContentAndReportFinish` treats any 200 on it as its own
+  // copy result — a settings save landing there leaves it with no
+  // `newContentIds` to render.
+  const settingsFetcher = useFetcher();
 
   const isAssigned = activity.assignmentInfo
     ? activity.assignmentInfo.assignmentStatus !== "Unassigned"
@@ -272,7 +279,7 @@ export function CompoundActivityEditor({
         repeatInProblemSet:
           content.type === "singleDoc" ? content.repeatInProblemSet : undefined,
         updateRepeatInProblemSet: (copies) => {
-          fetcher.submit(
+          settingsFetcher.submit(
             {
               path: "updateContent/updateContentSettings",
               contentId: content.contentId,


### PR DESCRIPTION
`CompoundActivityEditor` shares a single fetcher with its popups, and `CopyContentAndReportFinish` assumed that any 200 arriving on it was its own copy result, reading `data.newContentIds` from the response. When a per-document settings save landed there instead, `newContentIds` came back `undefined` — which slips past the existing `=== null` guard and crashes the render on `.length`.

Hitting it takes some timing. The copy modal is mounted whenever `addTo !== null`, and "Items from Explore" sets that *before* it navigates, so there is a window where the modal is mounted and listening. Changing a document's Repeat control during that window took the editor down. It turned up on dev3, where navigation is slow enough to leave the window open; it does not reproduce locally.

## What changed

Per-document settings updates now use their own fetcher, so their responses never reach the popups at all.

`CopyContentAndReportFinish` now accepts a response only when it actually carries an array `newContentIds`. That guard holds for all six of its call sites.

`MoveCopyContent` had the same assumption and the same latent crash — reporting the action finished on any 200, and crashing on the copy path reading `data.newContentIds.length`. It cannot use the same guard, because `moveContent` returns no payload at all, so a successful move is indistinguishable from any other 200. It now tracks whether it started the submission instead: a ref armed immediately before each submit, consumed in the effect, and cleared whenever the modal opens.

## Testing

`MoveCopyContent.cy.tsx` 13/13 and `CopyContentAndReportFinish.cy.tsx` 16/16. Each gained a test that puts a foreign 200 on the shared fetcher and asserts the modal neither claims success nor crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Code taken from #3026)