### PR TITLE
Compile repeatInProblemSet correctly and consistently

### DIFF
--- a/apps/api/src/query/activity_edit_view.ts
+++ b/apps/api/src/query/activity_edit_view.ts
@@ -84,7 +84,6 @@ export async function getContent({
   includeClassifications = false,
   includeShareDetails = false,
   includeOwnerDetails = false,
-  includeRepeatInProblemSet = false,
   isEditor = false,
   skipPermissionCheck = false,
 }: {
@@ -94,7 +93,6 @@ export async function getContent({
   includeClassifications?: boolean;
   includeShareDetails?: boolean;
   includeOwnerDetails?: boolean;
-  includeRepeatInProblemSet?: boolean;
   isEditor?: boolean;
   skipPermissionCheck?: boolean;
 }) {
@@ -149,7 +147,6 @@ export async function getContent({
     includeClassifications,
     includeShareDetails,
     includeOwnerDetails,
-    includeRepeatInProblemSet,
   });
 
   const preliminaryList = await prisma.content.findMany({

--- a/apps/api/src/query/assign.ts
+++ b/apps/api/src/query/assign.ts
@@ -13,6 +13,7 @@ import {
 import { getRandomValues } from "crypto";
 import { AssignmentMode, ContentType, Prisma } from "@prisma/client";
 import { Content, ItemScores, ScoreData, UserInfo } from "../types";
+import { repeatCountInProblemSet } from "@doenet-tools/shared";
 import { fromUUID, isEqualUUID } from "../utils/uuid";
 import { processContent, returnContentSelect } from "../utils/contentStructure";
 import { InvalidRequestError } from "../utils/error";
@@ -865,7 +866,13 @@ export async function getAssignmentResponseStudent({
       children: {
         where: { isDeletedOn: null },
         orderBy: { sortIndex: "asc" },
-        select: { name: true, type: true, numToSelect: true },
+        select: {
+          name: true,
+          type: true,
+          numToSelect: true,
+          repeatInProblemSet: true,
+          numVariants: true,
+        },
       },
     },
   });
@@ -1411,7 +1418,25 @@ async function getAllAttemptScores({
   }
 }
 
-/** Get a list of the names of the documents/selects in `content`, in original order. */
+/**
+ * Names for the `count` items that `name` contributes to an activity,
+ * disambiguated by index unless there is just the one.
+ */
+function repeatedItemNames(name: string, count: number) {
+  if (count <= 1) {
+    return [name];
+  }
+  return Array.from({ length: count }, (_, i) => `${name} (${i + 1})`);
+}
+
+/**
+ * Get a list of the names of the documents/selects in `content`, in original order.
+ *
+ * The result must line up one-to-one with the items of the compiled activity
+ * (see `compileActivityFromContent`), since the item names label the columns of
+ * the gradebook indexed by `itemNumber`. So a question bank contributes one name
+ * per selected item and a repeated document one name per copy.
+ */
 function getItemNames(
   content:
     | Content
@@ -1423,36 +1448,27 @@ function getItemNames(
           name: string;
           type: ContentType;
           numToSelect: number;
+          repeatInProblemSet?: number;
+          numVariants?: number;
         }[];
       },
 ) {
-  const itemNames: string[] = [];
-
   if (content.type === "select") {
-    if (content.numToSelect === 1) {
-      itemNames.push(content.name);
-    } else {
-      for (let i = 1; i <= content.numToSelect; i++) {
-        itemNames.push(`${content.name} (${i})`);
-      }
-    }
-  } else if (content.type === "sequence") {
-    for (const child of content.children) {
-      if (child.type === "singleDoc") {
-        itemNames.push(child.name);
-      } else if (child.type === "select") {
-        if (child.numToSelect === 1) {
-          itemNames.push(child.name);
-        } else {
-          for (let i = 1; i <= child.numToSelect; i++) {
-            itemNames.push(`${child.name} (${i})`);
-          }
-        }
-      }
-    }
+    return repeatedItemNames(content.name, content.numToSelect);
+  }
+  if (content.type !== "sequence") {
+    return [];
   }
 
-  return itemNames;
+  return content.children.flatMap((child) => {
+    if (child.type === "singleDoc") {
+      return repeatedItemNames(child.name, repeatCountInProblemSet(child));
+    }
+    if (child.type === "select") {
+      return repeatedItemNames(child.name, child.numToSelect);
+    }
+    return [];
+  });
 }
 
 /**

--- a/apps/api/src/query/editor.ts
+++ b/apps/api/src/query/editor.ts
@@ -305,7 +305,6 @@ export async function getCompoundEditorView({
     isEditor,
     skipPermissionCheck: true,
     includeAssignInfo: true,
-    includeRepeatInProblemSet: true,
   });
 
   return {
@@ -350,7 +349,6 @@ export async function getCompoundEditorEdit({
     loggedInUserId,
     isEditor,
     skipPermissionCheck: true,
-    includeRepeatInProblemSet: true,
   });
 
   return { content };

--- a/apps/api/src/test/activity.test.ts
+++ b/apps/api/src/test/activity.test.ts
@@ -3,7 +3,14 @@ import { describe, expect, test, vi } from "vitest";
 import { DateTime } from "luxon";
 
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
-import { createTestUser, doc, fold, pset, setupTestContent } from "./utils";
+import {
+  createTestUser,
+  doc,
+  fold,
+  pset,
+  qbank,
+  setupTestContent,
+} from "./utils";
 import {
   createContent,
   deleteContent,
@@ -28,6 +35,7 @@ import { modifyContentSharedWith, setContentIsPublic } from "../query/share";
 import {
   closeAssignment,
   createAssignment,
+  getAssignmentResponseOverview,
   updateAssignmentClosedOn,
 } from "../query/assign";
 import { createNewAttempt, saveScoreAndState } from "../query/scores";
@@ -43,6 +51,7 @@ import { setContentLicense } from "../query/license";
 import { updateVisibility } from "../access";
 import { fromUUID, isEqualUUID } from "../utils/uuid";
 import { Doc } from "../types";
+import { compileActivityFromContent } from "../utils/contentStructure";
 import {
   InvalidRequestError,
   PermissionDeniedRedirectError,
@@ -275,7 +284,6 @@ test("Test updating repeatInProblemSet", async () => {
     const result = (await getContent({
       contentId: psDoc,
       loggedInUserId: userId,
-      includeRepeatInProblemSet: true,
     })) as Doc;
     return result.repeatInProblemSet;
   }
@@ -306,6 +314,147 @@ test("Test updating repeatInProblemSet", async () => {
     repeatInProblemSet: 24,
   });
   expect(await repeatVal()).eqls(23);
+});
+
+test("repeatInProblemSet survives into the compiled activity", async () => {
+  const { userId } = await createTestUser();
+  const [ps, psDoc] = await setupTestContent(userId, {
+    ps: pset({
+      psDoc: doc(`<selectFromSequence from="1" to="5"/>`),
+    }),
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    numVariants: 5,
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    repeatInProblemSet: 3,
+  });
+
+  // A plain `getContent` must carry the setting, since it is what every
+  // activity-compiling caller (revisions, cids, assignments) uses.
+  const content = await getContent({ contentId: ps, loggedInUserId: userId });
+  const source = compileActivityFromContent(content);
+
+  if (source.type !== "sequence") {
+    throw Error("shouldn't happen");
+  }
+
+  // the repeated document is wrapped in a select that picks 3 variants.
+  // Mirrored by "wraps a repeated document in a select, as the server does"
+  // in `apps/app/src/utils/activity.cy.tsx` — the client compiler produces the
+  // source for every viewer path, so the two must stay in agreement.
+  const item = source.items[0];
+  expect(item.type).eqls("select");
+  if (item.type !== "select") {
+    throw Error("shouldn't happen");
+  }
+  expect(item.id).eqls(`select_for_${fromUUID(psDoc)}`);
+  expect(item.title).eqls("Repeat 3 times");
+  expect(item.numToSelect).eqls(3);
+  expect(item.selectByVariant).eqls(true);
+  expect(item.items.length).eqls(1);
+
+  const inner = item.items[0];
+  if (inner.type !== "singleDoc") {
+    throw Error("shouldn't happen");
+  }
+  expect(inner.id).eqls(fromUUID(psDoc));
+  // the document carries its title, as it does on the client
+  expect(inner.title).eqls("psDoc");
+});
+
+test("A document is repeated no more times than it has variants", async () => {
+  const { userId } = await createTestUser();
+  const [ps, psDoc] = await setupTestContent(userId, {
+    ps: pset({
+      psDoc: doc(`<selectFromSequence from="1" to="5"/>`),
+    }),
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    numVariants: 5,
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    repeatInProblemSet: 3,
+  });
+
+  // Editing the document down to fewer variants leaves the larger repeat in
+  // place, and the editor offers no way to lower it: the repeat control is
+  // shown only for a document with more than one variant.
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    numVariants: 2,
+  });
+
+  const content = await getContent({ contentId: ps, loggedInUserId: userId });
+  const source = compileActivityFromContent(content);
+  if (source.type !== "sequence") {
+    throw Error("shouldn't happen");
+  }
+  const item = source.items[0];
+  if (item.type !== "select") {
+    throw Error("shouldn't happen");
+  }
+  expect(item.numToSelect).eqls(2);
+  expect(item.title).eqls("Repeat 2 times");
+
+  // The item names label the gradebook columns, so they follow the same cap.
+  const { assignmentId } = await createAssignment({
+    contentId: ps,
+    loggedInUserId: userId,
+    closedOn: DateTime.now().plus({ days: 1 }),
+    destinationParentId: null,
+  });
+  const { itemNames } = await getAssignmentResponseOverview({
+    contentId: assignmentId,
+    loggedInUserId: userId,
+  });
+  expect(itemNames).eqls(["psDoc (1)", "psDoc (2)"]);
+});
+
+test("A document in a question bank is not repeated", async () => {
+  const { userId } = await createTestUser();
+  const [_ps, psDoc, bank] = await setupTestContent(userId, {
+    ps: pset({
+      psDoc: doc(`<selectFromSequence from="1" to="5"/>`),
+    }),
+    bank: qbank({}),
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    numVariants: 5,
+  });
+  await updateContent({
+    contentId: psDoc,
+    loggedInUserId: userId,
+    repeatInProblemSet: 3,
+  });
+
+  // The setting travels with the document when it moves, but a question bank
+  // already selects from its documents: a nested select would put more items
+  // in the activity than `numToSelect` accounts for.
+  await moveContent({
+    contentId: psDoc,
+    changeParentIdTo: bank,
+    desiredPosition: 0,
+    loggedInUserId: userId,
+  });
+
+  const content = await getContent({ contentId: bank, loggedInUserId: userId });
+  const source = compileActivityFromContent(content);
+  if (source.type !== "select") {
+    throw Error("shouldn't happen");
+  }
+  expect(source.items[0].type).eqls("singleDoc");
 });
 
 test("deleteContent marks a activity and document as deleted and prevents its retrieval", async () => {

--- a/apps/api/src/test/assign.test.ts
+++ b/apps/api/src/test/assign.test.ts
@@ -7,6 +7,7 @@ import {
   fold,
   getTestAssignment,
   pset,
+  qbank,
   setupTestContent,
 } from "./utils";
 import { DateTime } from "luxon";
@@ -622,6 +623,48 @@ test("cannot assign sub-part of problem set", async () => {
       destinationParentId: null,
     }),
   ).rejects.toThrow();
+});
+
+test("item names expand question banks and repeats", async () => {
+  const owner = await createTestUser();
+  const ownerId = owner.userId;
+
+  const [psId, problemId, _bankId] = await setupTestContent(ownerId, {
+    "A problem set": pset({
+      Problem: doc(`<selectFromSequence from="1" to="5"/>`),
+      Bank: qbank({
+        "Question A": doc("a"),
+        "Question B": doc("b"),
+      }),
+    }),
+  });
+
+  await updateContent({
+    contentId: problemId,
+    loggedInUserId: ownerId,
+    numVariants: 5,
+  });
+  await updateContent({
+    contentId: problemId,
+    loggedInUserId: ownerId,
+    repeatInProblemSet: 2,
+  });
+
+  const { assignmentId } = await createAssignment({
+    contentId: psId,
+    loggedInUserId: ownerId,
+    closedOn: DateTime.now().plus({ days: 1 }),
+    destinationParentId: null,
+  });
+
+  // The item names label the gradebook columns, so they must line up one-to-one
+  // with the items of the compiled activity: the twice-repeated problem
+  // contributes two, and the question bank one per selection.
+  const { itemNames } = await getAssignmentResponseOverview({
+    contentId: assignmentId,
+    loggedInUserId: ownerId,
+  });
+  expect(itemNames).eqls(["Problem (1)", "Problem (2)", "Bank"]);
 });
 
 test("cannot change closedOn, maxAttempts, mode, individualizeByStudent of a non-root assignment activity", async () => {

--- a/apps/api/src/utils/contentStructure.ts
+++ b/apps/api/src/utils/contentStructure.ts
@@ -15,7 +15,7 @@ import {
 import { sortClassifications } from "./classificationsCategories";
 import { fromUUID, isEqualUUID } from "./uuid";
 import { DateTime } from "luxon";
-import { ActivitySource } from "@doenet-tools/shared";
+import { ActivitySource, repeatCountInProblemSet } from "@doenet-tools/shared";
 import { InvalidRequestError } from "./error";
 import { imageSourceFromStorageKey } from "../media/upload.schema";
 
@@ -151,7 +151,6 @@ export function returnContentSelect({
   includeClassifications = false,
   includeShareDetails = false,
   includeOwnerDetails = false,
-  includeRepeatInProblemSet = false,
 }) {
   const sharedWith = {
     select: includeShareDetails
@@ -253,10 +252,15 @@ export function returnContentSelect({
     _count: { select: { contentStates: true } },
   };
 
+  // `repeatInProblemSet` is a setting for a document inside a problem set. It
+  // determines the item structure of the compiled activity, so it is always
+  // selected: every caller that compiles an activity — including for
+  // revisions, cids, and assigned content — needs it.
   const docSelect = {
     numVariants: true,
     source: true,
     doenetmlVersion: true,
+    repeatInProblemSet: true,
   };
 
   const questionBankSelect = {
@@ -269,16 +273,11 @@ export function returnContentSelect({
     paginate: true,
   };
 
-  const repeatInProblemSetSelect = includeRepeatInProblemSet && {
-    repeatInProblemSet: true,
-  };
-
   return {
     ...baseSelect,
     ...docSelect,
     ...questionBankSelect,
     ...problemSetSelect,
-    ...repeatInProblemSetSelect,
     ...assignmentSelect,
   };
 }
@@ -645,16 +644,21 @@ export function returnClassificationListSelect() {
  * rather than the full doenetml version. Useful for generating a cid from the source
  * that won't change if we upgrade the minor version for all documents (though it does not
  * produce a valid source for viewing the activity).
+ *
+ * `inProblemSet` says whether `activity` is a child of a problem set, which is
+ * where the document setting `repeatInProblemSet` applies.
  */
 export function compileActivityFromContent(
   activity: Content,
   useVersionIds = false,
+  inProblemSet = false,
 ): ActivitySource {
   switch (activity.type) {
     case "singleDoc": {
       const documentJson = {
         id: fromUUID(activity.contentId),
         type: activity.type,
+        title: activity.name,
         isDescription: false,
         doenetML: activity.doenetML!,
         version: useVersionIds
@@ -662,14 +666,15 @@ export function compileActivityFromContent(
           : activity.doenetmlVersion.fullVersion,
         numVariants: activity.numVariants,
       };
-      if (activity.repeatInProblemSet && activity.repeatInProblemSet > 1) {
+      const repeatCount = inProblemSet ? repeatCountInProblemSet(activity) : 1;
+      if (repeatCount > 1) {
         // If the document repeats, wrap this document in
         // a `select` which can select that many variants.
         return {
           id: `select_for_${fromUUID(activity.contentId)}`,
           type: "select",
-          title: `Repeat ${activity.repeatInProblemSet} times`,
-          numToSelect: activity.repeatInProblemSet,
+          title: `Repeat ${repeatCount} times`,
+          numToSelect: repeatCount,
           selectByVariant: true,
           items: [documentJson],
         };
@@ -685,7 +690,7 @@ export function compileActivityFromContent(
         numToSelect: activity.numToSelect,
         selectByVariant: activity.selectByVariant,
         items: activity.children.map((child) =>
-          compileActivityFromContent(child, useVersionIds),
+          compileActivityFromContent(child, useVersionIds, false),
         ),
       };
     }
@@ -696,7 +701,7 @@ export function compileActivityFromContent(
         title: activity.name,
         shuffle: activity.shuffle,
         items: activity.children.map((child) =>
-          compileActivityFromContent(child, useVersionIds),
+          compileActivityFromContent(child, useVersionIds, true),
         ),
       };
     }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,4 @@ export * from "./apiTypes.js";
 export * from "./logic/browsable.js";
 export * from "./logic/categoryRules.js";
 export * from "./logic/mediaLicense.js";
+export * from "./logic/problemSetItems.js";

--- a/packages/shared/src/logic/problemSetItems.test.ts
+++ b/packages/shared/src/logic/problemSetItems.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { repeatCountInProblemSet } from "./problemSetItems.js";
+
+describe("repeatCountInProblemSet", () => {
+  test("a document with no settings appears once", () => {
+    expect(repeatCountInProblemSet({})).eqls(1);
+    expect(repeatCountInProblemSet({ numVariants: 5 })).eqls(1);
+  });
+
+  test("a repeated document appears that many times", () => {
+    expect(
+      repeatCountInProblemSet({ repeatInProblemSet: 3, numVariants: 5 }),
+    ).eqls(3);
+  });
+
+  test("the repeat is capped by the number of variants", () => {
+    expect(
+      repeatCountInProblemSet({ repeatInProblemSet: 3, numVariants: 2 }),
+    ).eqls(2);
+    expect(
+      repeatCountInProblemSet({ repeatInProblemSet: 3, numVariants: 1 }),
+    ).eqls(1);
+  });
+
+  test("the repeat is at least one", () => {
+    expect(
+      repeatCountInProblemSet({ repeatInProblemSet: 0, numVariants: 5 }),
+    ).eqls(1);
+  });
+});

--- a/packages/shared/src/logic/problemSetItems.ts
+++ b/packages/shared/src/logic/problemSetItems.ts
@@ -1,0 +1,20 @@
+/**
+ * The number of copies of a document that a problem set contains.
+ *
+ * The document is repeated `repeatInProblemSet` times, capped by the number of
+ * variants it has: each copy uses a different variant, and `numVariants` can
+ * drop below a previously saved `repeatInProblemSet` (by editing the source or
+ * reverting the document to an earlier revision).
+ *
+ * Both activity compilers and the gradebook's item names go through this, so
+ * that the item count derived for the gradebook matches the compiled activity.
+ */
+export function repeatCountInProblemSet(doc: {
+  repeatInProblemSet?: number;
+  numVariants?: number;
+}) {
+  return Math.max(
+    1,
+    Math.min(doc.repeatInProblemSet ?? 1, doc.numVariants ?? 1),
+  );
+}


### PR DESCRIPTION
> **Before deploying:** run `SELECT COUNT(*) FROM content WHERE repeatInProblemSet > 1`, and read the behavior change at the bottom. Checked on prod 2026-08-17: of 15 rows, six are soft-deleted and three sit in assigned problem sets, all experimental — nothing needed resetting. Re-check if time has passed.

`repeatInProblemSet` was only selected when a caller passed `includeRepeatInProblemSet: true`, and most callers did not. `createContentRevision` was one of them, so the setting vanished from stored revision sources and the cids derived from them. The compound-editor preview was the only place that ever saw it.

Selecting it unconditionally is a one-line change. The rest of this PR is the three bugs that were hiding behind it.

## A repeat could escape its problem set

The setting lives on the document row, and `moveContent` and `copyContent` carry the whole row — so a document repeated in a problem set keeps `repeatInProblemSet > 1` after being moved into a question bank.

The compiler's repeat branch was never scoped to a problem set. Once the field is actually selected, that compiles a `select` *inside* the bank, producing more items than the bank's `numToSelect` accounts for and more than `getItemNames` labels. The repeat now applies only to a direct child of a `sequence`.

## A repeat could outlive its variants

The repeat is clamped to `numVariants` at the moment it is set, but `numVariants` moves independently afterwards — by editing the source down to fewer variants, or through `revertToRevision`, which writes `numVariants` straight to the row.

A stale `repeat = 3` on a document that now has two variants asked the viewer for three distinct variants of two. The repeat is now capped at `numVariants` at compile time, and `getItemNames` applies the same cap so the gradebook columns still line up.

That rule lives in exactly one place, `repeatCountInProblemSet` in `packages/shared`. The compiler and `getItemNames` are its only callers, so the item count derived for the gradebook cannot drift from the compiled activity.

## Item names did not account for repeats

`getItemNames` produces the gradebook column labels indexed by `itemNumber`, so it has to line up one-to-one with the items of the compiled activity. It expanded a question bank into one name per selection, but gave a repeated document a single name — harmless while repeats were being dropped, wrong the moment they compile.

It now expands a repeat the same way (`Problem (1)`, `Problem (2)`), sharing one helper with the question-bank case. `getAssignmentResponseStudent` selects `repeatInProblemSet` and `numVariants` on its children so its own call site gets the same answer.

## The title gap

The server now emits `title` on a document, which the client compiler already did. Closing the gap on the *server* side is deliberate: the server-compiled source only feeds revision cids, so no student's `sourceHash` changes. Removing `title` from the client instead would have invalidated saved state for every problem set.

## Behavior change

Problem sets with `repeat > 1` now compile to more items than before, so existing attempts on that content will hash-mismatch and start fresh. `repeat = 1` — the default, and the overwhelming majority — compiles byte-identically and is unaffected.

This changes revision cids and gradebook item names right away, while students only see the extra items once the matching client-side change ships. That is a separate PR so this one can deploy on its own, but the two want to go out close together.

## Testing

`packages/shared` covers `repeatCountInProblemSet` directly: the default of one, a plain repeat, the `numVariants` cap in both directions, and the floor of one.

New API tests cover `repeatInProblemSet` surviving into the compiled activity from a plain `getContent` call, a repeat capped at `numVariants` after the document is edited down (in the compiled source *and* in the item names), a repeated document moved into a question bank compiling to a plain document, and item names for a problem set coming out as `["Problem (1)", "Problem (2)", "Bank"]`.

Each was checked adversarially: reverting the `inProblemSet` gate, the `numVariants` cap, or the item-name expansion makes exactly the intended test fail, and only that test.

`tsc --noEmit` passes on `apps/api`. **The API integration suite has not been run against a live database — please confirm `npm test -w @doenet-tools/api` before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
