### PR TITLE
fix(api): validate Google's profile payload instead of trusting passport's reshape

### DIFF
--- a/apps/api/src/auth/asyncPassport.test.ts
+++ b/apps/api/src/auth/asyncPassport.test.ts
@@ -14,7 +14,6 @@ const Authenticator = (
     };
   }
 ).Authenticator;
-type GoogleProfile = { name?: { givenName: string } };
 
 describe("asyncPassport", () => {
   beforeEach(() => {
@@ -47,19 +46,20 @@ describe("asyncPassport", () => {
     expect(done.mock.calls[0][0]).toBe(boom);
   });
 
-  it("catches the exact production failure: reading a field off an absent profile", async () => {
-    // Google omits `name` entirely when the account has neither given nor
-    // family name, which crashed the server on 2026-08-23.
+  it("catches a handler dereferencing an absent nested field", async () => {
+    // The shape of the 2026-08-23 outage: a handler read a field off an object
+    // the provider had not sent. What Google actually sends, and how it is
+    // validated, is covered in `googleProfile.test.ts`; this test is only about
+    // the resulting TypeError reaching `done` instead of the process.
     const done = vi.fn();
-    const profile: GoogleProfile = {};
     const wrapped = asyncPassport(
-      "google",
-      async (user: GoogleProfile, _cb: Done) => {
+      "deref",
+      async (user: { name?: { givenName: string } }, _cb: Done) => {
         return user.name!.givenName;
       },
     );
 
-    wrapped(profile as never, done as never);
+    wrapped({} as never, done as never);
     await vi.waitFor(() => {
       expect(done).toHaveBeenCalledTimes(1);
       expect(done.mock.calls[0][0]).toBeInstanceOf(TypeError);

--- a/apps/api/src/auth/asyncPassport.ts
+++ b/apps/api/src/auth/asyncPassport.ts
@@ -1,4 +1,4 @@
-type DoneCallback = (err: unknown, result?: unknown) => void;
+export type DoneCallback = (err: unknown, result?: unknown) => void;
 
 /**
  * Wraps an `async` Passport callback so a rejection can never escape.

--- a/apps/api/src/auth/googleProfile.test.ts
+++ b/apps/api/src/auth/googleProfile.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
+import { toGoogleAccount } from "./googleProfile";
+
+/**
+ * Payloads are written the way Google sends them -- snake_case OIDC claims --
+ * rather than the way `passport-google-oauth20` reshapes them, because the
+ * reshape is what this module exists to bypass.
+ */
+describe("toGoogleAccount", () => {
+  it("reads a complete profile", () => {
+    expect(
+      toGoogleAccount({
+        sub: "108000000000000000001",
+        email: "ada@example.com",
+        email_verified: true,
+        given_name: "Ada",
+        family_name: "Lovelace",
+        name: "Ada Lovelace",
+      }),
+    ).toEqual({
+      email: "ada@example.com",
+      firstNames: "Ada",
+      lastNames: "Lovelace",
+    });
+  });
+
+  it("handles an account with no family name", () => {
+    // The 2026-08-23 outage. `family_name` is an optional OIDC claim and Google
+    // omits it for mononymous accounts; it reached Prisma as a missing required
+    // argument and killed the process.
+    expect(
+      toGoogleAccount({
+        sub: "108000000000000000002",
+        email: "gavin@example.com",
+        email_verified: true,
+        given_name: "Gavin",
+        name: "Gavin",
+      }),
+    ).toEqual({
+      email: "gavin@example.com",
+      firstNames: "Gavin",
+      lastNames: "",
+    });
+  });
+
+  it("handles an account with no name claims at all", () => {
+    // The second failure mode: with neither name claim, passport builds no
+    // `profile.name` object, so reading `.givenName` off it threw a TypeError.
+    expect(
+      toGoogleAccount({
+        sub: "108000000000000000003",
+        email: "someone@example.com",
+        email_verified: true,
+      }),
+    ).toEqual({
+      email: "someone@example.com",
+      firstNames: null,
+      lastNames: "",
+    });
+  });
+
+  it("does not trust an unverified email address", () => {
+    expect(
+      toGoogleAccount({
+        sub: "108000000000000000004",
+        email: "not-really-mine@example.com",
+        email_verified: false,
+        given_name: "Mallory",
+      }),
+    ).toEqual({
+      email: "108000000000000000004@google.com",
+      firstNames: "Mallory",
+      lastNames: "",
+    });
+  });
+
+  it("falls back to the account id when no email is present", () => {
+    // `email` is only sent when the `email` scope was granted.
+    expect(toGoogleAccount({ sub: "108000000000000000005" })).toEqual({
+      email: "108000000000000000005@google.com",
+      firstNames: null,
+      lastNames: "",
+    });
+  });
+
+  it("accepts email_verified as a string", () => {
+    expect(
+      toGoogleAccount({
+        sub: "108000000000000000006",
+        email: "stringly@example.com",
+        email_verified: "true",
+      }).email,
+    ).toBe("stringly@example.com");
+  });
+
+  it("ignores claims it does not know about", () => {
+    // Google adding a claim must not be able to fail a login.
+    expect(
+      toGoogleAccount({
+        sub: "108000000000000000007",
+        email: "future@example.com",
+        email_verified: true,
+        given_name: "Future",
+        family_name: "Claim",
+        some_claim_added_in_2027: { nested: true },
+      }),
+    ).toEqual({
+      email: "future@example.com",
+      firstNames: "Future",
+      lastNames: "Claim",
+    });
+  });
+
+  it("rejects a payload with no subject", () => {
+    // `sub` is the one claim OIDC guarantees, and the account identity depends
+    // on it. Failing here fails one login; `asyncPassport` turns it into
+    // `done(err)`.
+    expect(() => toGoogleAccount({ email: "nobody@example.com" })).toThrow(
+      ZodError,
+    );
+  });
+
+  it("rejects a payload that is not an object", () => {
+    expect(() => toGoogleAccount(undefined)).toThrow(ZodError);
+    expect(() => toGoogleAccount("not a profile")).toThrow(ZodError);
+  });
+
+  it("rejects a claim of the wrong type", () => {
+    expect(() =>
+      toGoogleAccount({ sub: "108000000000000000008", family_name: 42 }),
+    ).toThrow(ZodError);
+  });
+});

--- a/apps/api/src/auth/googleProfile.ts
+++ b/apps/api/src/auth/googleProfile.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+/**
+ * Google's OpenID Connect user info payload, as reached through
+ * `profile._json` on a `passport-google-oauth20` profile.
+ *
+ * Why validate `_json` rather than trust `profile`?
+ *
+ * `profile.name.familyName` is not a field Google sends. Google sends
+ * `family_name`, and `passport-google-oauth20` reshapes it in
+ * `lib/profile/openid.js`:
+ *
+ *     if (json.family_name || json.given_name) {
+ *       profile.name = { familyName: json.family_name,
+ *                        givenName:  json.given_name };
+ *     }
+ *
+ * Both branches of that reshape produced production crashes. A user with a
+ * given name but no family name yielded `familyName: undefined`, which reached
+ * Prisma as a missing required argument. A user with neither yielded no `name`
+ * key at all, so reading `.givenName` off it threw a TypeError.
+ *
+ * `@types/passport` declares that shape as `{ familyName: string; givenName:
+ * string }` -- non-optional, and wrong. That is the general problem with
+ * answering this with types alone: a `.d.ts` is a claim about a third party's
+ * payload, checked at build time and never again. This schema is a claim that
+ * is checked on every login, at the point the data crosses into our system --
+ * the same discipline `queryLoggedIn` already applies to request bodies.
+ *
+ * Fields are optional here because OIDC says they are. `family_name` and
+ * `given_name` are listed as optional standard claims; only `sub` is
+ * guaranteed. Unknown keys are stripped rather than rejected, so Google adding
+ * a claim cannot break a login.
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+ */
+export const googleProfileJsonSchema = z.object({
+  sub: z.string().min(1),
+  email: z.string().optional(),
+  // Spec'd as a boolean, but string forms appear in the wild often enough that
+  // rejecting them would mean failing real logins over a formatting detail.
+  email_verified: z.union([z.boolean(), z.enum(["true", "false"])]).optional(),
+  given_name: z.string().optional(),
+  family_name: z.string().optional(),
+  name: z.string().optional(),
+  picture: z.string().optional(),
+});
+
+export type GoogleProfileJson = z.infer<typeof googleProfileJsonSchema>;
+
+/** The fields this application actually stores for a Google account. */
+export type GoogleAccount = {
+  email: string;
+  firstNames: string | null;
+  lastNames: string;
+};
+
+/**
+ * Validate a Google profile payload and reduce it to the fields we store.
+ *
+ * Throws `ZodError` if the payload is not recognizably a Google profile, which
+ * `asyncPassport` routes to `done(err)` -- a failed login rather than a failed
+ * process.
+ *
+ * A missing family name becomes `""`, which is how this codebase already
+ * represents an unknown last name: the magic-link path creates users with
+ * `lastNames: ""`, and `findOrCreateUser` treats `""` as the sentinel that lets
+ * a real name backfill it later. Making the column nullable instead would add a
+ * third state without adding meaning, and would break that backfill.
+ */
+export function toGoogleAccount(raw: unknown): GoogleAccount {
+  const json = googleProfileJsonSchema.parse(raw);
+
+  const verified =
+    json.email_verified === true || json.email_verified === "true";
+
+  return {
+    // An unverified or absent address must not claim the namespace of a real
+    // one, so it falls back to a value derived from the Google account id.
+    email: json.email && verified ? json.email : `${json.sub}@google.com`,
+    firstNames: json.given_name ?? null,
+    lastNames: json.family_name ?? "",
+  };
+}

--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -1,8 +1,21 @@
 // `auth` — helpers for the Passport authentication path.
 //
-//   asyncPassport — wrap an async Passport callback so a rejection reaches
-//                   `done(err)` instead of escaping as an unhandled rejection
+//   asyncPassport      — wrap an async Passport callback so a rejection reaches
+//                        `done(err)` instead of escaping as an unhandled rejection
+//   toGoogleAccount    — validate Google's raw OIDC payload and reduce it to the
+//                        fields we store
+//   SessionUser        — the payload shapes that reach `serializeUser`
 //
 // Import from here, not from a source file.
 
 export { asyncPassport } from "./asyncPassport";
+export type { DoneCallback } from "./asyncPassport";
+export { toGoogleAccount, googleProfileJsonSchema } from "./googleProfile";
+export type { GoogleAccount, GoogleProfileJson } from "./googleProfile";
+export type {
+  SessionUser,
+  GoogleSessionUser,
+  MagicLinkSessionUser,
+  LocalSessionUser,
+  AnonymousSessionUser,
+} from "./sessionUser";

--- a/apps/api/src/auth/sessionUser.ts
+++ b/apps/api/src/auth/sessionUser.ts
@@ -1,0 +1,52 @@
+/**
+ * The payload shapes that reach `passport.serializeUser`.
+ *
+ * Passport's own types assume a single `Express.User` that round-trips: the
+ * value `serializeUser` receives is the same type `deserializeUser` produces.
+ * That is not true here. Four strategies each hand `serializeUser` a different
+ * shape, and `index.ts` augments `Request["user"]` to `UserInfoWithEmail` --
+ * the *deserialized* type, which none of these are. So the shapes are declared
+ * here instead of borrowed from `@types/passport`.
+ *
+ * Each strategy's payload is produced by the corresponding `passport.use(...)`
+ * call in `index.ts`; the anonymous one comes from
+ * `passport-anonymous/lib/strategy.ts`, which calls `this.success({ anonymous:
+ * true })`.
+ */
+
+/**
+ * A `passport-google-oauth20` profile, narrowed to what `serializeUser` reads.
+ *
+ * `_json` is deliberately `unknown`: it is Google's raw payload, and the point
+ * of `toGoogleAccount` is that nothing may read it before it is validated. The
+ * reshaped `profile.name` is not declared at all, because that reshape is where
+ * the production crashes came from.
+ */
+export type GoogleSessionUser = {
+  provider: "google";
+  _json: unknown;
+  /** Set by the Google verify callback when upgrading an anonymous session. */
+  fromAnonymous?: string;
+};
+
+export type MagicLinkSessionUser = {
+  provider: "magiclink";
+  email: string;
+  fromAnonymous: string;
+};
+
+export type LocalSessionUser = {
+  provider: "local";
+  userId: Uint8Array;
+};
+
+export type AnonymousSessionUser = {
+  provider?: undefined;
+  anonymous: true;
+};
+
+export type SessionUser =
+  | GoogleSessionUser
+  | MagicLinkSessionUser
+  | LocalSessionUser
+  | AnonymousSessionUser;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -52,7 +52,8 @@ import { metricsRouter } from "./routes/metricsRoutes";
 import { contentRouter } from "./routes/content.route";
 import { loadMediaConfig, mediaRouter } from "./media";
 import { getEnvVar } from "./utils/env";
-import { asyncPassport } from "./auth";
+import { asyncPassport, toGoogleAccount } from "./auth";
+import type { DoneCallback, SessionUser } from "./auth";
 import { installProcessErrorHandlers } from "./errors/processErrorHandlers";
 
 // Type assertion to work around passport type declaration issues
@@ -280,8 +281,7 @@ passport.use(new AnonymIdStrategy());
 passport.serializeUser(
   asyncPassport(
     "serializeUser",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async (req: any, user: any, done: any) => {
+    async (req: Request, user: SessionUser, done: DoneCallback) => {
       if (user.provider === "magiclink") {
         const email: string = user.email;
         const fromAnonymous: string = user.fromAnonymous;
@@ -310,11 +310,11 @@ passport.serializeUser(
 
         return done(undefined, fromUUID(u.userId));
       } else if (user.provider === "google") {
-        let email = user.id + "@google.com";
-        if (user.emails[0].verified) {
-          email = user.emails[0].value;
-        }
-        const fromAnonymous: string = user.fromAnonymous;
+        // Validated here rather than read off `profile.name`, which is
+        // passport's reshape of Google's payload and is where two production
+        // crashes came from. See `auth/googleProfile.ts`.
+        const { email, firstNames, lastNames } = toGoogleAccount(user._json);
+        const fromAnonymous = user.fromAnonymous;
 
         let u;
 
@@ -328,8 +328,8 @@ passport.serializeUser(
             // Use name from google account
             await updateUser({
               loggedInUserId: u.userId,
-              firstNames: user.name.givenName,
-              lastNames: user.name.familyName,
+              firstNames: firstNames ?? undefined,
+              lastNames,
             });
           } catch (_e) {
             console.log("Error upgrading anonymous user", _e);
@@ -338,11 +338,7 @@ passport.serializeUser(
         }
 
         if (!u) {
-          u = await findOrCreateUser({
-            email,
-            firstNames: user.name.givenName,
-            lastNames: user.name.familyName,
-          });
+          u = await findOrCreateUser({ email, firstNames, lastNames });
         }
 
         return done(undefined, fromUUID(u.userId));
@@ -404,8 +400,7 @@ passport.serializeUser(
 passport.deserializeUser(
   asyncPassport(
     "deserializeUser",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async (userId: string, done: any) => {
+    async (userId: string, done: DoneCallback) => {
       const { user } = await getMyUserInfo({
         loggedInUserId: toUUID(userId),
       });

--- a/apps/api/src/routes/loginRoutes.ts
+++ b/apps/api/src/routes/loginRoutes.ts
@@ -5,6 +5,7 @@ import { getUser, getUserInfoFromEmail } from "../query/user";
 import axios from "axios";
 import { convertUUID } from "../utils/uuid";
 import { UserInfoWithEmail } from "../types";
+import { toGoogleAccount } from "../auth";
 
 // Type assertion to work around passport type declaration issues
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -25,12 +26,48 @@ if (
   );
 }
 
+/**
+ * Where to send the browser after a successful Google login.
+ *
+ * `family_name` is an optional OIDC standard claim, so a Google account can
+ * authenticate perfectly well and still arrive with no last name -- the same
+ * state every magic-link user starts in. The magic-link flow asks for a name at
+ * exactly this point (`ConfirmSignIn.tsx`) and the assignment flow refuses to
+ * start without one (`AssignmentViewer.tsx`). This gives Google logins the same
+ * gate, rather than being the one entry path that drops a nameless user into
+ * the app.
+ */
+async function landingPageAfterGoogleLogin(req: Request): Promise<string> {
+  try {
+    // `req.user` here is the Google profile that `serializeUser` consumed, not
+    // a deserialized user: Passport sets it to whatever the strategy produced.
+    // The stored record is therefore looked up by re-deriving the email with
+    // the same `toGoogleAccount` call `serializeUser` used, so the two
+    // derivations cannot drift apart.
+    const { email } = toGoogleAccount(
+      (req.user as unknown as { _json?: unknown })._json,
+    );
+    const user = await getUserInfoFromEmail(email);
+
+    return user.lastNames ? "/" : "/changeName?redirect=/";
+  } catch (e) {
+    // The login itself already succeeded -- only the name check failed. Letting
+    // them in beats failing a good login: `AssignmentViewer` still refuses to
+    // start an assignment without a name.
+    console.error("[Auth] Could not check name after Google login", e);
+    return "/";
+  }
+}
+
 loginRouter.get(
   "/google",
-  passport.authenticate("google", {
-    successRedirect: "/",
-    failureRedirect: "/login",
-  }),
+  // No `successRedirect`, so Passport calls the next handler on success.
+  passport.authenticate("google", { failureRedirect: "/login" }),
+  // `landingPageAfterGoogleLogin` handles its own errors and never rejects,
+  // which matters because Express 4 ignores a rejected handler promise.
+  async (req: Request, res: Response) => {
+    res.redirect(await landingPageAfterGoogleLogin(req));
+  },
 );
 
 loginRouter.get(


### PR DESCRIPTION
Follow-up to #3035. That PR stopped a malformed Google profile from killing the server. This one fixes the login it was trying to perform.

## The bug

`profile.name.familyName` is not a field Google sends. Google sends `family_name`, and `passport-google-oauth20` reshapes it in `lib/profile/openid.js`:

```js
if (json.family_name || json.given_name) {
  profile.name = { familyName: json.family_name,
                   givenName:  json.given_name };
}
```

Both branches of that reshape crashed production on 2026-08-23:

| Google's account | What passport built | What happened |
|---|---|---|
| `given_name` only | `{ familyName: undefined, givenName: "…" }` | Prisma: `Argument 'lastNames' is missing` |
| neither claim | no `name` key at all | `TypeError: Cannot read properties of undefined (reading 'givenName')` |

`family_name` is an [optional OIDC standard claim](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). Both are legitimate Google accounts — mononymous users, mostly.

## Why not just fix the types

This is the reviewer question from #3035, and the honest answer is that types alone would not have caught it. `@types/passport` already declares that shape as `{ familyName: string; givenName: string }` — non-optional, and wrong. Swapping in a Google-maintained `.d.ts` just changes which file you trust: it is still a build-time claim about a third party's runtime payload, checked once and never again.

So this reads `profile._json` — Google's actual payload, before passport touches it — through a zod schema that runs on **every login**. Same discipline `queryLoggedIn` already applies to request bodies, now applied at the other trust boundary.

The schema is deliberately permissive where permissiveness is safe: unknown claims are stripped rather than rejected, so Google adding a field cannot fail a login. It is strict about `sub`, because account identity depends on it.

## Dropping the `any`

Also from the #3035 review. The `any` on the callback parameters is gone; the module-level `passportLib as any` stays, because that one is a real `export =` interop problem unrelated to these callbacks.

Passport's own types could not express this. They assume one `Express.User` that round-trips, but four strategies hand `serializeUser` four different shapes, and `index.ts:71` augments `Request["user"]` to `UserInfoWithEmail` — the *deserialized* type, which none of them are. `auth/sessionUser.ts` declares the four instead.

With it in place, TypeScript rejects the line that caused the outage:

```
src/index.ts(341,64): error TS2339: Property 'name' does not exist on type 'GoogleSessionUser'.
```

## A note on `lastNames`

I said in the #3035 review that I'd make the column nullable. Having looked at what that touches, I don't think it's right, and I'd rather say so than do it quietly.

`""` is *already* this codebase's representation of an unknown last name. The magic-link path creates users with `lastNames: ""`, and `findOrCreateUser` has this:

```ts
if (lastNames !== "" && user.lastNames == "") {
  // backfill once a real name shows up
}
```

Making the column nullable would add a third state with no new meaning, break that backfill, and turn `lastNames` into `string | null` across ~200 call sites in the API and the frontend. Happy to be argued out of this, but it looked like risk without benefit.

## Asking for a name when Google doesn't supply one

Validating the payload keeps the server up, but it doesn't answer what a mononymous user's name *should* be. This app already has an answer, and `lastNames === ""` is already the flag for it:

- `ConfirmSignIn.tsx:41` sends a magic-link user to `/changeName` when `lastNames === ""` — every magic-link user starts in that state.
- `AssignmentViewer.tsx:101` refuses to start an assignment without a name, which is the case that actually matters: a submission has to be attributable to a person.

Google was the one entry path with no such gate. `successRedirect: "/"` is a server-side redirect that fires before anything can look at the stored user, so a nameless Google user landed in the app and was only caught later, if they happened to open an assignment.

Dropping `successRedirect` lets Passport call the next handler on success ([`authenticate.js:277-280`](https://github.com/jaredhanson/passport/blob/master/lib/middleware/authenticate.js)), which looks up the stored user and forwards to `/changeName` when the name is missing. Three things I checked in passport's source rather than assumed:

- The authorization-request leg of the same route is unaffected — `strategy.redirect` calls `res.end()` and never reaches the handler.
- Without `successRedirect`, success falls through to `next()`.
- `req.logIn` sets `req.user` to the payload the *strategy* produced, so `req.user` here is the Google profile, not a deserialized user. The email is re-derived with the same `toGoogleAccount` call `serializeUser` used, so the two cannot drift. (The existing `/handle` route relies on the same fact.)

If that lookup fails the login still succeeds and the user is let in — failing a good login would be worse, and `AssignmentViewer` still holds the line.

This part is routing glue with no unit test; it's covered by typecheck and by the three source facts above. The `/api/login/google` round trip needs real Google credentials, so it isn't reachable from CI.

## Behavior change

Mononymous Google users can log in. They get `firstNames: "Gavin"`, `lastNames: ""`, and are sent to "Enter your name" before reaching the app — the same first-run experience a magic-link user already has. Google users who *do* have a family name are unaffected and still land on `/`.

One incidental fix: the old code read `user.emails[0].verified` unguarded, which would have thrown for an account granted `profile` scope but not `email`. That path now falls back to the `sub`-derived address like the unverified case does.

## Tests

`googleProfile.test.ts` — 10 cases driven by payloads written the way Google sends them, including both outage payloads verbatim, unverified/absent email, string-valued `email_verified`, unknown claims, and malformed input.

`asyncPassport.test.ts` — the hand-written `GoogleProfile` type is gone (the other #3035 review comment). That test was never about Google; it's about a TypeError reaching `done` instead of the process, so it now uses an anonymous shape and the Google specifics live with the schema.

18/18 unit tests pass; `tsc` at the existing 53-error baseline with zero errors in `auth/` or `index.ts`; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTADrF3AdyanA9o3tm57Vn
