### PR TITLE
feat: feature flags for decoupling deploy from release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,10 @@ In production, `app` is built as static files served by Express.
 
 Development uses a fork workflow. Push branches to `origin` (your fork), then open a PR targeting `upstream/main`. Merged PRs deploy to production after human sign-off.
 
+Ship cross-cutting API + client changes behind a **feature flag** so each side
+can deploy on its own and the feature is switched on afterwards — see
+`apps/api/src/feature-flags/README.md`.
+
 Database and API changes must follow the **expand-migrate-contract** pattern: each merged PR must be safe to deploy on its own, so add new columns/endpoints before removing old ones across separate PRs.
 
 ## Cross-cutting Conventions

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -48,3 +48,8 @@ DISCOURSE_URL="https://community.example.com"
 DISCOURSE_SSO_SECRET="mysecret"
 DISCOURSE_API_KEY="mysecret"
 DISCOURSE_API_USERNAME="system"
+#Feature flags (see src/feature-flags/README.md)
+#Both optional. Flags are normally toggled with `scripts/feature-flag.ts`,
+#which writes the database; these are only for tuning and local pinning.
+#FEATURE_FLAGS_CACHE_TTL_MS="15000"
+#FEATURE_FLAG_OVERRIDES="someFlag=on,otherFlag=off"

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -52,6 +52,22 @@ When adding endpoints that read or modify content, check whether visibility gati
 
 Four content types throughout the domain model: `"singleDoc"`, `"select"` (question bank), `"sequence"` (problem set), `"folder"`. These appear in Prisma enums and TypeScript union types.
 
+## Feature Flags
+
+Changes that span the API and client ship behind a flag: merge with the flag
+off, deploy each side independently, then turn it on with no redeploy.
+
+- The flag list lives in `packages/shared/src/types/featureFlags.ts` (typed, so a
+  misspelled flag is a build error); the database only stores overrides.
+- Read a flag with `isFeatureEnabled("name")` from `src/feature-flags`
+  (client side: `useFeatureFlag` in `apps/app/src/utils/featureFlags.ts`).
+- Flip one with `npx tsx scripts/feature-flag.ts on <flag>` — there is no HTTP
+  write endpoint.
+
+Write the flag's **off** path as today's behavior and the **on** path as
+additive; that is what keeps expand-migrate-contract intact. See
+`src/feature-flags/README.md`.
+
 ## Environment Variables
 
 `DATABASE_URL` must be kept in sync with the individual `DATABASE_*` vars manually — Prisma uses `DATABASE_URL` while Docker uses the individual vars. Update both if any connection detail changes.

--- a/apps/api/prisma/migrations/20260824120000_add_feature_flags/migration.sql
+++ b/apps/api/prisma/migrations/20260824120000_add_feature_flags/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE `featureFlags` (
+    `name` VARCHAR(191) NOT NULL,
+    `enabled` BOOLEAN NOT NULL,
+    `note` TEXT NULL,
+    `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`name`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -536,3 +536,16 @@ enum LibraryEventType {
   ADD_COMMENT
   // EDIT_COMMENT
 }
+
+/// Runtime overrides for the feature-flag registry in `@doenet-tools/shared`.
+/// A row exists only for a flag that has been explicitly turned on or off; with
+/// no row, the registry's `defaultEnabled` applies. Rows for flags no longer in
+/// the registry are ignored (safe to leave behind, cleaned up with
+/// `feature-flag prune`). See `apps/api/src/feature-flags/README.md`.
+model featureFlags {
+  name      String   @id @db.VarChar(191)
+  enabled   Boolean
+  /// Why it was flipped, and by whom — free text, for the audit trail.
+  note      String?  @db.Text
+  updatedAt DateTime @default(now()) @updatedAt
+}

--- a/apps/api/scripts/feature-flag.ts
+++ b/apps/api/scripts/feature-flag.ts
@@ -1,0 +1,135 @@
+// Turns feature flags on and off in one environment, without a deploy.
+// This is the *only* write path for flags — there is no HTTP endpoint — so
+// flipping one takes the same access as any other database script.
+// -----
+// Local dev (from apps/api, requires tsx):
+//   npx tsx scripts/feature-flag.ts list
+//   npx tsx scripts/feature-flag.ts on  <flag> ["why, and who asked"]
+//   npx tsx scripts/feature-flag.ts off <flag> ["why"]
+//   npx tsx scripts/feature-flag.ts clear <flag>     # back to the code default
+//   npx tsx scripts/feature-flag.ts prune            # drop rows for deleted flags
+//
+// Production (inside the running ECS Fargate task, cwd is /DoenetTools/apps/api):
+//   node dist/scripts/feature-flag.js on <flag>
+//
+// To reach the prod container: run `infra/scripts/exec.sh -s prod` from the repo
+// root, pick the api service/task, then run the command above. The change takes
+// effect on every API task within FEATURE_FLAGS_CACHE_TTL_MS (~15s by default).
+// -----
+import {
+  FEATURE_FLAGS,
+  FEATURE_FLAG_NAMES,
+  isFeatureFlagName,
+  type FeatureFlagName,
+} from "@doenet-tools/shared";
+import { prisma } from "../src/model";
+import {
+  clearFeatureFlag,
+  getFeatureFlags,
+  listFeatureFlagRows,
+  pruneFeatureFlagRows,
+  setFeatureFlag,
+} from "../src/feature-flags";
+
+const USAGE = `Usage:
+  feature-flag list
+  feature-flag on    <flag> [note]
+  feature-flag off   <flag> [note]
+  feature-flag clear <flag>
+  feature-flag prune
+
+Known flags: ${FEATURE_FLAG_NAMES.join(", ") || "(none)"}`;
+
+function requireFlagName(raw: string | undefined): FeatureFlagName {
+  if (!raw || !isFeatureFlagName(raw)) {
+    console.error(`Unknown feature flag: ${JSON.stringify(raw)}\n\n${USAGE}`);
+    process.exit(2);
+  }
+  return raw;
+}
+
+async function list() {
+  const values = await getFeatureFlags();
+  const rows = await listFeatureFlagRows();
+  const byName = new Map(rows.map((r) => [r.name, r]));
+
+  for (const name of FEATURE_FLAG_NAMES) {
+    const row = byName.get(name);
+    const source = row
+      ? `set ${row.updatedAt.toISOString()}${row.note ? ` — ${row.note}` : ""}`
+      : `code default (${FEATURE_FLAGS[name].defaultEnabled ? "on" : "off"})`;
+    console.log(
+      `${values[name] ? "ON  " : "off "} ${name.padEnd(28)} ${source}`,
+    );
+    console.log(`     ${FEATURE_FLAGS[name].description}`);
+  }
+
+  // Env pins beat the database, so a value can disagree with the row above.
+  if (process.env.FEATURE_FLAG_OVERRIDES) {
+    console.log(
+      `\nEnv pins: FEATURE_FLAG_OVERRIDES=${process.env.FEATURE_FLAG_OVERRIDES}`,
+    );
+  }
+
+  const stale = rows.filter((r) => !isFeatureFlagName(r.name));
+  if (stale.length > 0) {
+    console.log(
+      `\nRows for flags no longer in the registry (ignored; \`prune\` to remove): ${stale
+        .map((r) => r.name)
+        .join(", ")}`,
+    );
+  }
+}
+
+async function main() {
+  const [command, flagArg, note] = process.argv.slice(2);
+
+  switch (command) {
+    case "list":
+    case undefined:
+      await list();
+      return;
+
+    case "on":
+    case "off": {
+      const name = requireFlagName(flagArg);
+      await setFeatureFlag(name, command === "on", note);
+      console.log(
+        `${name} is now ${command.toUpperCase()} in this environment.`,
+      );
+      return;
+    }
+
+    case "clear": {
+      const name = requireFlagName(flagArg);
+      await clearFeatureFlag(name);
+      console.log(
+        `${name} reset to its code default (${FEATURE_FLAGS[name].defaultEnabled ? "on" : "off"}).`,
+      );
+      return;
+    }
+
+    case "prune": {
+      const pruned = await pruneFeatureFlagRows();
+      console.log(
+        pruned.length > 0
+          ? `Removed rows for unknown flags: ${pruned.join(", ")}`
+          : "Nothing to prune.",
+      );
+      return;
+    }
+
+    default:
+      console.error(USAGE);
+      process.exit(2);
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/api/src/feature-flags/README.md
+++ b/apps/api/src/feature-flags/README.md
@@ -87,6 +87,16 @@ read of the flag, delete its registry entry, then run
 `feature-flag prune` to drop the leftover database rows. Rows for unknown flags
 are ignored in the meantime, so the order is safe either way.
 
+If the feature has shipped but you aren't ready to pull the flag out yet, set
+`defaultEnabled: true` and prune. **`defaultEnabled: true` means "this has
+shipped — delete me"**, not "this is on by default": it makes the released
+behavior the baseline in every environment (fresh dev databases, CI, Cypress),
+which otherwise keeps running the retired path until someone writes a row there.
+Don't reach for it to ship a feature on-by-default with a kill switch — the
+defaults are what a cold API task and a client with a failed flag fetch fall back
+to, so a flag you just turned off comes back **on** for them. Use a
+`FEATURE_FLAG_OVERRIDES` pin for break-glass instead.
+
 ## Configuration
 
 | Env var                      | Required | Default | Notes                                                        |

--- a/apps/api/src/feature-flags/README.md
+++ b/apps/api/src/feature-flags/README.md
@@ -1,0 +1,105 @@
+# feature-flags
+
+Runtime toggles that decouple **deploying** code from **releasing** a feature.
+
+The workflow this exists for: a change spans the API and the client, both halves
+merge to `main` behind a flag that is off, they deploy on their own schedules,
+and then — once the backend is live everywhere — the flag is flipped and the
+frontend starts using it. No coordinated deploy, and turning it back off is one
+command, not a revert-and-redeploy.
+
+## How a value is resolved
+
+```
+   FEATURE_FLAG_OVERRIDES env pin      (dev / e2e / break-glass · needs restart)
+ ▶ featureFlags row in the database    (the live toggle · `feature-flag` CLI)
+ ▶ defaultEnabled in the registry      (what a fresh deploy does)
+```
+
+Highest match wins. Values are cached in-process for
+`FEATURE_FLAGS_CACHE_TTL_MS` (15s default), so reading a flag is a map lookup
+and a flip reaches every API task within one TTL.
+
+## Files
+
+| File                      | Responsibility                                               |
+| ------------------------- | ------------------------------------------------------------ |
+| `config.ts`               | Env validation: cache TTL and `FEATURE_FLAG_OVERRIDES` pins. |
+| `featureFlags.service.ts` | Resolve + cache values; read/write helpers used by the CLI.  |
+| `router.ts`               | `GET /api/featureFlags` (read-only).                         |
+
+The registry — the list of flags that exist — lives in `@doenet-tools/shared`
+(`packages/shared/src/types/featureFlags.ts`) so the API and client share one
+typed list and a typo is a build error. The database only ever stores overrides.
+
+## Adding a flag
+
+1. Add an entry to `FEATURE_FLAGS` in `packages/shared/src/types/featureFlags.ts`
+   with `defaultEnabled: false`, a description, an owner, and today's date.
+2. Read it where it matters:
+
+   ```ts
+   // API
+   import { isFeatureEnabled } from "../feature-flags";
+   if (await isFeatureEnabled("newEditor")) { ... }
+   ```
+
+   ```tsx
+   // apps/app — any component under the site header
+   import { useFeatureFlag } from "../utils/featureFlags";
+   const showNewEditor = useFeatureFlag("newEditor");
+   ```
+
+3. Merge and deploy. The flag is off, so nothing changes for users.
+4. Turn it on where you want it (below).
+
+Write both sides of a flagged change so the **off** path is the current behavior
+and the **on** path is additive — that is what makes deploying and releasing
+separable, and it keeps expand-migrate-contract intact.
+
+## Flipping a flag
+
+Writes are CLI-only — there is no HTTP write endpoint, so changing a flag takes
+the same access as any other database script.
+
+```bash
+# local dev, from apps/api
+npx tsx scripts/feature-flag.ts list
+npx tsx scripts/feature-flag.ts on  newEditor "enabling for the 8/24 release"
+npx tsx scripts/feature-flag.ts off newEditor "reports of broken preview"
+npx tsx scripts/feature-flag.ts clear newEditor   # back to the code default
+```
+
+In production, `infra/scripts/exec.sh -s prod` from the repo root, pick the api
+service/task, then:
+
+```bash
+node dist/scripts/feature-flag.js on newEditor "release 8/24"
+```
+
+Existing browser tabs pick the change up on their next full page load; the API
+picks it up within one cache TTL.
+
+## Removing a flag
+
+Flags are meant to be short-lived. Once a feature is permanently on: delete every
+read of the flag, delete its registry entry, then run
+`feature-flag prune` to drop the leftover database rows. Rows for unknown flags
+are ignored in the meantime, so the order is safe either way.
+
+## Configuration
+
+| Env var                      | Required | Default | Notes                                                        |
+| ---------------------------- | -------- | ------- | ------------------------------------------------------------ |
+| `FEATURE_FLAGS_CACHE_TTL_MS` | no       | 15000   | How long resolved values are cached; the flip-to-live delay. |
+| `FEATURE_FLAG_OVERRIDES`     | no       | —       | `"someFlag=on,other=off"` — pins that beat the database.     |
+
+`FEATURE_FLAG_OVERRIDES` is for local dev and Cypress runs (turn a flag on with
+no database write) and as break-glass if the database is unavailable. An unknown
+flag name or unparsable value throws at startup rather than being ignored.
+
+## Failure behavior
+
+If the database can't be read, the last known values are served — or the registry
+defaults on a cold start — and the error is logged. An unreachable database must
+not simultaneously change the behavior of every flagged code path.

--- a/apps/api/src/feature-flags/config.ts
+++ b/apps/api/src/feature-flags/config.ts
@@ -1,0 +1,96 @@
+// Validated config for the feature-flags system.
+import { getEnvVar } from "../utils/env";
+import { isFeatureFlagName, type FeatureFlagName } from "@doenet-tools/shared";
+
+export type FeatureFlagsConfig = {
+  /**
+   * How long a resolved set of flag values is served before re-reading the
+   * database. This is the delay between flipping a flag and every API task
+   * agreeing on the new value, so keep it short — a flag read is one cached
+   * lookup, not a query.
+   */
+  cacheTtlMs: number;
+  /**
+   * Hard pins from `FEATURE_FLAG_OVERRIDES`, which beat the database. For local
+   * dev and Cypress runs (turn a flag on without touching the database), and as
+   * a break-glass path if the database is unreachable during an incident.
+   *
+   * Format: `FEATURE_FLAG_OVERRIDES="someFlag=on,otherFlag=off"`.
+   */
+  overrides: Partial<Record<FeatureFlagName, boolean>>;
+};
+
+const DEFAULT_TTL_MS = 15 * 1000;
+
+let cached: FeatureFlagsConfig | undefined;
+
+export function loadFeatureFlagsConfig(): FeatureFlagsConfig {
+  if (cached) return cached;
+
+  const ttlRaw = getEnvVar("FEATURE_FLAGS_CACHE_TTL_MS");
+  const cacheTtlMs = ttlRaw === undefined ? DEFAULT_TTL_MS : Number(ttlRaw);
+  if (!Number.isFinite(cacheTtlMs) || cacheTtlMs < 0) {
+    throw new Error(
+      `FEATURE_FLAGS_CACHE_TTL_MS must be a non-negative number of milliseconds (got ${JSON.stringify(ttlRaw)})`,
+    );
+  }
+
+  cached = {
+    cacheTtlMs,
+    overrides: parseOverrides(getEnvVar("FEATURE_FLAG_OVERRIDES")),
+  };
+  return cached;
+}
+
+/**
+ * Parses `"a=on,b=off"`. Unknown flag names and unparsable values throw: an
+ * override is an operator's explicit intent, and silently ignoring a typo would
+ * leave a flag in the opposite state from the one they asked for.
+ */
+export function parseOverrides(
+  raw: string | undefined,
+): Partial<Record<FeatureFlagName, boolean>> {
+  const overrides: Partial<Record<FeatureFlagName, boolean>> = {};
+  if (!raw) return overrides;
+
+  for (const entry of raw.split(",")) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+
+    const [name, value] = trimmed.split("=").map((part) => part.trim());
+    if (!isFeatureFlagName(name)) {
+      throw new Error(
+        `FEATURE_FLAG_OVERRIDES names an unknown feature flag: ${JSON.stringify(name)}`,
+      );
+    }
+
+    const enabled = parseBoolean(value);
+    if (enabled === undefined) {
+      throw new Error(
+        `FEATURE_FLAG_OVERRIDES value for ${name} must be on/off (got ${JSON.stringify(value)})`,
+      );
+    }
+    overrides[name] = enabled;
+  }
+  return overrides;
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  switch (value?.toLowerCase()) {
+    case "on":
+    case "true":
+    case "1":
+      return true;
+    case "off":
+    case "false":
+    case "0":
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+/** Test-only: clear the module-level cache between cases. */
+export function resetFeatureFlagsConfigForTest(): void {
+  cached = undefined;
+}

--- a/apps/api/src/feature-flags/featureFlags.service.test.ts
+++ b/apps/api/src/feature-flags/featureFlags.service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { FEATURE_FLAGS, type FeatureFlagName } from "@doenet-tools/shared";
+import { resolveFlagValues } from "./featureFlags.service";
+import { parseOverrides } from "./config";
+
+// Any flag from the registry, so these cases keep working as flags come and go.
+const FLAG = Object.keys(FEATURE_FLAGS)[0] as FeatureFlagName;
+const DEFAULT = FEATURE_FLAGS[FLAG].defaultEnabled;
+
+describe("resolveFlagValues", () => {
+  test("with no rows, every flag takes its registry default", () => {
+    const values = resolveFlagValues([]);
+    for (const [name, def] of Object.entries(FEATURE_FLAGS)) {
+      expect(values[name as FeatureFlagName]).toBe(def.defaultEnabled);
+    }
+  });
+
+  test("a database row overrides the registry default", () => {
+    const values = resolveFlagValues([{ name: FLAG, enabled: !DEFAULT }]);
+    expect(values[FLAG]).toBe(!DEFAULT);
+  });
+
+  test("an env pin beats the database row", () => {
+    const values = resolveFlagValues([{ name: FLAG, enabled: false }], {
+      [FLAG]: true,
+    });
+    expect(values[FLAG]).toBe(true);
+  });
+
+  test("rows for flags no longer in the registry are ignored", () => {
+    const values = resolveFlagValues([
+      { name: "flagDeletedLastRelease", enabled: true },
+    ]);
+    expect(values).not.toHaveProperty("flagDeletedLastRelease");
+    expect(values[FLAG]).toBe(DEFAULT);
+  });
+});
+
+describe("parseOverrides", () => {
+  test("unset or empty yields no pins", () => {
+    expect(parseOverrides(undefined)).toEqual({});
+    expect(parseOverrides("  ")).toEqual({});
+  });
+
+  test("parses on/off, true/false and 1/0, ignoring whitespace", () => {
+    expect(parseOverrides(` ${FLAG} = on `)).toEqual({ [FLAG]: true });
+    expect(parseOverrides(`${FLAG}=FALSE`)).toEqual({ [FLAG]: false });
+    expect(parseOverrides(`${FLAG}=1,`)).toEqual({ [FLAG]: true });
+  });
+
+  test("a misspelled flag name throws rather than silently doing nothing", () => {
+    expect(() => parseOverrides("nosuchFlag=on")).toThrow(
+      /unknown feature flag/,
+    );
+  });
+
+  test("an unparsable value throws", () => {
+    expect(() => parseOverrides(`${FLAG}=yes-please`)).toThrow(
+      /must be on\/off/,
+    );
+  });
+});

--- a/apps/api/src/feature-flags/featureFlags.service.ts
+++ b/apps/api/src/feature-flags/featureFlags.service.ts
@@ -1,0 +1,131 @@
+// Resolves feature-flag values, cheaply and without ever throwing at a call site.
+//
+// Precedence, highest first:
+//   1. `FEATURE_FLAG_OVERRIDES` env pins  (dev/e2e/break-glass — needs a restart)
+//   2. a `featureFlags` row in the database  (the live toggle)
+//   3. `defaultEnabled` in the shared registry  (what a fresh deploy does)
+//
+// Values are cached for `cacheTtlMs`, so a flag read is a map lookup rather than
+// a query, and a flip propagates to every API task within one TTL.
+import {
+  defaultFeatureFlagValues,
+  isFeatureFlagName,
+  type FeatureFlagName,
+  type FeatureFlagValues,
+} from "@doenet-tools/shared";
+import { prisma } from "../model";
+import { loadFeatureFlagsConfig } from "./config";
+
+type FlagRow = { name: string; enabled: boolean };
+
+/**
+ * Layers database rows and env pins onto the registry defaults. Pure — the
+ * whole precedence rule lives here so it can be tested without a database.
+ */
+export function resolveFlagValues(
+  rows: FlagRow[],
+  overrides: Partial<Record<FeatureFlagName, boolean>> = {},
+): FeatureFlagValues {
+  const values = defaultFeatureFlagValues();
+
+  for (const row of rows) {
+    // Rows for flags that have been deleted from the registry are ignored, so
+    // removing a flag from the code never needs a coordinated database cleanup.
+    if (isFeatureFlagName(row.name)) {
+      values[row.name] = row.enabled;
+    }
+  }
+
+  for (const [name, enabled] of Object.entries(overrides)) {
+    if (isFeatureFlagName(name) && enabled !== undefined) {
+      values[name] = enabled;
+    }
+  }
+
+  return values;
+}
+
+let cache: { values: FeatureFlagValues; expiresAt: number } | undefined;
+
+/**
+ * Every flag's current value. A database failure is not fatal: we serve the last
+ * good values (or the registry defaults on a cold cache) and log, because an
+ * unreachable database must not take down every flagged code path at once.
+ */
+export async function getFeatureFlags(): Promise<FeatureFlagValues> {
+  const { cacheTtlMs, overrides } = loadFeatureFlagsConfig();
+  const now = Date.now();
+
+  if (cache && cache.expiresAt > now) {
+    return cache.values;
+  }
+
+  let values: FeatureFlagValues;
+  try {
+    const rows = await prisma.featureFlags.findMany({
+      select: { name: true, enabled: true },
+    });
+    values = resolveFlagValues(rows, overrides);
+  } catch (e) {
+    console.error("Could not read feature flags; serving last known values", e);
+    values = cache?.values ?? resolveFlagValues([], overrides);
+  }
+
+  cache = { values, expiresAt: now + cacheTtlMs };
+  return values;
+}
+
+/** Whether one flag is on. The normal way server code reads a flag. */
+export async function isFeatureEnabled(
+  name: FeatureFlagName,
+): Promise<boolean> {
+  return (await getFeatureFlags())[name];
+}
+
+/**
+ * Turns a flag on or off for this environment. Used by the `feature-flag` CLI —
+ * there is deliberately no HTTP endpoint for writes, so flipping a flag requires
+ * the same access as running a database script.
+ */
+export async function setFeatureFlag(
+  name: FeatureFlagName,
+  enabled: boolean,
+  note?: string,
+): Promise<void> {
+  await prisma.featureFlags.upsert({
+    where: { name },
+    create: { name, enabled, note },
+    update: { enabled, note },
+  });
+  clearFeatureFlagCache();
+}
+
+/** Drops the override row, returning the flag to its registry default. */
+export async function clearFeatureFlag(name: FeatureFlagName): Promise<void> {
+  await prisma.featureFlags.deleteMany({ where: { name } });
+  clearFeatureFlagCache();
+}
+
+/** All override rows, including ones for flags no longer in the registry. */
+export async function listFeatureFlagRows() {
+  return prisma.featureFlags.findMany({ orderBy: { name: "asc" } });
+}
+
+/** Deletes rows whose flag is gone from the registry. Safe to run any time. */
+export async function pruneFeatureFlagRows(): Promise<string[]> {
+  const rows = await listFeatureFlagRows();
+  const stale = rows.map((r) => r.name).filter((n) => !isFeatureFlagName(n));
+  if (stale.length > 0) {
+    await prisma.featureFlags.deleteMany({ where: { name: { in: stale } } });
+    clearFeatureFlagCache();
+  }
+  return stale;
+}
+
+/**
+ * Forces the next read to hit the database. Called after a write in this
+ * process; other API tasks pick the change up when their own TTL lapses.
+ */
+export function clearFeatureFlagCache(): void {
+  cache = undefined;
+}

--- a/apps/api/src/feature-flags/index.ts
+++ b/apps/api/src/feature-flags/index.ts
@@ -1,0 +1,22 @@
+// `feature-flags` — runtime toggles that let backend and frontend changes ship
+// dark and be switched on afterwards, without a second deploy.
+//
+//   config                — env validation (TTL, `FEATURE_FLAG_OVERRIDES` pins)
+//   featureFlags.service  — resolve registry defaults + database rows + pins, cached
+//   router                — GET /api/featureFlags (read-only; writes are CLI-only)
+//
+// The set of flags themselves lives in `@doenet-tools/shared`
+// (`packages/shared/src/types/featureFlags.ts`) so the API and client share one
+// typed list. Import from here, not from a source file.
+
+export { loadFeatureFlagsConfig } from "./config";
+export { featureFlagsRouter } from "./router";
+export {
+  getFeatureFlags,
+  isFeatureEnabled,
+  setFeatureFlag,
+  clearFeatureFlag,
+  listFeatureFlagRows,
+  pruneFeatureFlagRows,
+  clearFeatureFlagCache,
+} from "./featureFlags.service";

--- a/apps/api/src/feature-flags/router.ts
+++ b/apps/api/src/feature-flags/router.ts
@@ -1,0 +1,23 @@
+import express from "express";
+import { handleErrors } from "../errors/routeErrorHandler";
+import type { FeatureFlagsResponse } from "@doenet-tools/shared";
+import { getFeatureFlags } from "./featureFlags.service";
+
+export const featureFlagsRouter = express.Router();
+
+// Public and read-only: the client needs flags before it knows who is logged in,
+// and flags gate unreleased UI, not access to data — anything that must stay
+// private is still enforced server-side. Writes happen through the
+// `feature-flag` CLI, never over HTTP. See ./README.md.
+featureFlagsRouter.get("/", async (_req, res) => {
+  try {
+    const flags = await getFeatureFlags();
+    // Short client-side cache: a browser tab picks up a flip within ~a minute
+    // (on its next load or poll) without hammering the API on every navigation.
+    res.set("Cache-Control", "public, max-age=15");
+    const body: FeatureFlagsResponse = { flags };
+    res.json(body);
+  } catch (e) {
+    handleErrors(res, e);
+  }
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -51,6 +51,7 @@ import { codeRouter } from "./routes/code";
 import { metricsRouter } from "./routes/metricsRoutes";
 import { contentRouter } from "./routes/content.route";
 import { loadMediaConfig, mediaRouter } from "./media";
+import { featureFlagsRouter } from "./feature-flags";
 import { getEnvVar, isTestAuthBypassEnabled } from "./utils/env";
 import { asyncPassport, toGoogleAccount } from "./auth";
 import type { DoneCallback, SessionUser } from "./auth";
@@ -457,6 +458,7 @@ app.use("/api/code", codeRouter);
 app.use("/api/metrics", metricsRouter);
 app.use("/api/content", contentRouter);
 app.use("/api/media", mediaRouter);
+app.use("/api/featureFlags", featureFlagsRouter);
 
 // Discourse uses this endpoint to sign on
 app.use("/api/discourse", discourseRouter);

--- a/apps/app/src/paths/SiteHeader.tsx
+++ b/apps/app/src/paths/SiteHeader.tsx
@@ -11,6 +11,8 @@ import {
 import { Navbar } from "../features/navbar";
 import { MaintenanceBanner } from "../widgets/MaintenanceBanner";
 import { ThemeSettingProvider, useThemeSetting } from "../utils/theme";
+import { fetchFeatureFlags } from "../utils/featureFlags";
+import type { FeatureFlagValues } from "@doenet-tools/shared";
 
 const navBarHeight = "40px";
 
@@ -22,9 +24,14 @@ export type SiteContext = {
   setAddTo: (_: ContentDescription | null) => void;
   allLicenses: License[];
   allDoenetmlVersions: DoenetmlVersion[];
+  /** Read these with `useFeatureFlag()` from `utils/featureFlags`. */
+  featureFlags: FeatureFlagValues;
 };
 
 export async function loader() {
+  // Kicked off first and awaited last, so flags cost no extra round trip.
+  const featureFlagsPromise = fetchFeatureFlags();
+
   const {
     data: { user },
   } = await axios.get("/api/user/getMyUserInfo");
@@ -37,7 +44,9 @@ export async function loader() {
     data: { allDoenetmlVersions },
   } = await axios.get("/api/info/getAllDoenetmlVersions");
 
-  return { user, allLicenses, allDoenetmlVersions };
+  const featureFlags = await featureFlagsPromise;
+
+  return { user, allLicenses, allDoenetmlVersions, featureFlags };
 }
 
 /**
@@ -47,11 +56,13 @@ export async function loader() {
  * Includes skip navigation link for accessibility.
  */
 export function SiteHeader() {
-  const { user, allLicenses, allDoenetmlVersions } = useLoaderData() as {
-    user?: UserInfoWithEmail;
-    allLicenses: License[];
-    allDoenetmlVersions: DoenetmlVersion[];
-  };
+  const { user, allLicenses, allDoenetmlVersions, featureFlags } =
+    useLoaderData() as {
+      user?: UserInfoWithEmail;
+      allLicenses: License[];
+      allDoenetmlVersions: DoenetmlVersion[];
+      featureFlags: FeatureFlagValues;
+    };
 
   const [exploreTab, setExploreTab] = useState<number | null>(null);
 
@@ -67,6 +78,7 @@ export function SiteHeader() {
     setAddTo,
     allLicenses,
     allDoenetmlVersions,
+    featureFlags,
   };
 
   return (

--- a/apps/app/src/utils/featureFlags.ts
+++ b/apps/app/src/utils/featureFlags.ts
@@ -1,0 +1,44 @@
+// Client-side feature flags. The flag list itself lives in
+// `@doenet-tools/shared`, so `useFeatureFlag("nope")` is a compile error.
+//
+// Flags are fetched once by the root loader (`SiteHeader`) and handed down
+// through `SiteContext`. A flag flipped on the server reaches an open tab on its
+// next full page load; anything more eager isn't worth a poll, since flags gate
+// unreleased UI rather than live data.
+import { useOutletContext } from "react-router";
+import axios from "axios";
+import {
+  defaultFeatureFlagValues,
+  type FeatureFlagName,
+  type FeatureFlagValues,
+  type FeatureFlagsResponse,
+} from "@doenet-tools/shared";
+
+/**
+ * Reads flags for the root loader. Never rejects: if the request fails, the
+ * registry defaults apply and the site renders its released behavior, rather
+ * than the whole page failing over a flag lookup.
+ */
+export async function fetchFeatureFlags(): Promise<FeatureFlagValues> {
+  try {
+    const { data } = await axios.get<FeatureFlagsResponse>("/api/featureFlags");
+    // Merge onto the defaults so a flag added in this build but missing from an
+    // older API's response is `false` rather than `undefined`.
+    return { ...defaultFeatureFlagValues(), ...data.flags };
+  } catch (e) {
+    console.error("Could not load feature flags; using defaults", e);
+    return defaultFeatureFlagValues();
+  }
+}
+
+/**
+ * Whether a flag is on, inside any component rendered under the site header:
+ *
+ *   const showNewEditor = useFeatureFlag("newEditor");
+ */
+export function useFeatureFlag(name: FeatureFlagName): boolean {
+  const { featureFlags } = useOutletContext<{
+    featureFlags: FeatureFlagValues;
+  }>();
+  return featureFlags[name];
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./types/activityViewer.js";
 export * from "./types/categories.js";
+export * from "./types/featureFlags.js";
 export * from "./utils/ipfs.js";
 export * from "./utils/test.js";
 export * from "./apiTypes.js";

--- a/packages/shared/src/types/featureFlags.ts
+++ b/packages/shared/src/types/featureFlags.ts
@@ -1,0 +1,70 @@
+// The feature-flag registry: the single source of truth for which flags exist.
+//
+// Both the API (`apps/api/src/feature-flags`) and the client
+// (`apps/app/src/utils/featureFlags.ts`) import from here, so a flag name is a
+// TypeScript type — a typo is a build error, not a silently-off feature.
+//
+// Adding a flag: add an entry below with `defaultEnabled: false`, ship it, then
+// turn it on in an environment with `feature-flag on <name>` (see the API
+// README). Removing a flag: delete the entry *after* deleting every read of it;
+// leftover database rows for unknown flags are ignored.
+
+export type FeatureFlagDefinition = {
+  /** What the flag gates, in one line. Shown by the `feature-flag` CLI. */
+  description: string;
+  /**
+   * Value used when the database has no row for this flag. New flags ship
+   * `false`: the code deploys dark, then is switched on without a redeploy.
+   */
+  defaultEnabled: boolean;
+  /** Who to ask about this flag. */
+  owner: string;
+  /** ISO date the flag was added — flags are meant to be short-lived. */
+  addedOn: string;
+};
+
+export const FEATURE_FLAGS = {
+  // ---------------------------------------------------------------------
+  // Template. Copy this entry for a real flag, then delete this one once
+  // there is at least one other flag in the registry (the registry must not
+  // be empty, or `FeatureFlagName` becomes `never`).
+  // ---------------------------------------------------------------------
+  exampleFlag: {
+    description:
+      "Example flag — not read anywhere. Useful for verifying the toggle pipeline end to end.",
+    defaultEnabled: false,
+    owner: "doenet-devs",
+    addedOn: "2026-08-24",
+  },
+} as const satisfies Record<string, FeatureFlagDefinition>;
+
+export type FeatureFlagName = keyof typeof FEATURE_FLAGS & string;
+
+/** Every flag's effective value, resolved for one request. */
+export type FeatureFlagValues = Record<FeatureFlagName, boolean>;
+
+/** Wire shape of `GET /api/featureFlags`. */
+export type FeatureFlagsResponse = {
+  flags: FeatureFlagValues;
+};
+
+export const FEATURE_FLAG_NAMES = Object.keys(
+  FEATURE_FLAGS,
+) as FeatureFlagName[];
+
+export function isFeatureFlagName(name: string): name is FeatureFlagName {
+  return Object.prototype.hasOwnProperty.call(FEATURE_FLAGS, name);
+}
+
+/**
+ * The registry defaults, used before flags load (client) and as the base layer
+ * the database overrides (server). Never throws, never fetches — a flag read is
+ * always answerable.
+ */
+export function defaultFeatureFlagValues(): FeatureFlagValues {
+  const values = {} as FeatureFlagValues;
+  for (const name of FEATURE_FLAG_NAMES) {
+    values[name] = FEATURE_FLAGS[name].defaultEnabled;
+  }
+  return values;
+}


### PR DESCRIPTION
Adds a feature-flag system so a change spanning the API and the client can merge and deploy behind an **off** flag, then be switched on afterwards — no coordinated deploy, and rollback is a toggle rather than a revert.

## How a value is resolved

```
   FEATURE_FLAG_OVERRIDES env pin      (dev / e2e / break-glass · needs restart)
 ▶ featureFlags row in the database    (the live toggle)
 ▶ defaultEnabled in the registry      (what a fresh deploy does)
```

Values are cached in-process for `FEATURE_FLAGS_CACHE_TTL_MS` (15s default), so reading a flag is a map lookup and a flip reaches every API task within one TTL.

## What's here

- **Registry** (`packages/shared/src/types/featureFlags.ts`) — one typed list of flags shared by API and client, so a misspelled flag name is a build error. The database only ever stores overrides; rows for flags deleted from the registry are ignored, so removing a flag needs no coordinated cleanup.
- **API** (`apps/api/src/feature-flags/`) — resolution + cache, and `GET /api/featureFlags` (read-only). A database read failure serves last-known values and logs, rather than changing the behavior of every flagged code path at once.
- **Toggling** (`apps/api/scripts/feature-flag.ts`) — `list` / `on` / `off` / `clear` / `prune`. CLI-only, no HTTP write path, so flipping a flag takes the same access as any other database script (same pattern as `enable-image-upload.ts`). In prod: `infra/scripts/exec.sh -s prod`, then `node dist/scripts/feature-flag.js on <flag>`.
- **Client** (`apps/app/src/utils/featureFlags.ts`) — flags are fetched by the root `SiteHeader` loader (kicked off first, awaited last, so no added round trip), handed down via `SiteContext`, and read with `useFeatureFlag("name")`. A failed fetch falls back to registry defaults so a flag lookup can't break a page.
- **Migration** `20260824120000_add_feature_flags` — additive; `prisma migrate diff` reports no drift against the model.
- Docs in `apps/api/src/feature-flags/README.md`, plus pointers in the root and API `AGENTS.md`.

The registry ships with a single `exampleFlag` template entry, read nowhere — it exists so the registry isn't empty (which would make `FeatureFlagName` be `never`) and to verify the toggle pipeline end to end. Delete it once a real flag lands.

## Usage

```ts
// API
import { isFeatureEnabled } from "../feature-flags";
if (await isFeatureEnabled("newEditor")) { ... }
```

```tsx
// apps/app
const showNewEditor = useFeatureFlag("newEditor");
```

Write the **off** path as today's behavior and the **on** path as additive — that is what keeps expand-migrate-contract intact.

## Testing

- Unit tests for precedence, unknown-flag rows, and `FEATURE_FLAG_OVERRIDES` parsing (8 tests). Full API suite passes.
- Manually verified end to end against a local database: CLI flip → `{"flags":{"exampleFlag":true}}` on the live endpoint within the TTL → `clear` back to default.

## Open question

The 15s TTL trades a tiny indexed query per task every 15s for near-instant flips. Happy to raise it if that's the wrong balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qSbKP4eKRpUSUFGDCV5sQ
